### PR TITLE
Send meta posts to slack

### DIFF
--- a/tor/core/inbox.py
+++ b/tor/core/inbox.py
@@ -22,12 +22,15 @@ MOD_SUPPORT_PHRASES = [
 
 
 def forward_to_slack(item, config):
-    send_to_slack(
-        f'Unhandled inbox reply by *{item.author}* -- *{item.subject}*: '
-        f'{item.body}', config)
+    username = item.author.name
 
+    send_to_slack(
+        f'Unhandled message by '
+        f'<https://reddit.com/user/{username}|u/{username}> -- '
+        f'*{item.subject}*:\n{item.body}', config
+    )
     logging.info(
-        f'Received unhandled inbox message from {item.author}. \n Subject: '
+        f'Received unhandled inbox message from {username}. \n Subject: '
         f'{item.subject}\n\nBody: {item.body} '
     )
 

--- a/tor/helpers/flair.py
+++ b/tor/helpers/flair.py
@@ -140,3 +140,6 @@ def set_meta_flair_on_other_posts(config):
                 f'Meta. '
             )
             flair_post(post, flair.meta)
+            send_to_slack(
+                f'New meta post: <{post.url}|{post.fullname}>'
+            )


### PR DESCRIPTION
This adds a slack message for meta posts, and slightly improves the formatting of the slack messages for unhandled replies.