### PR TITLE
Allows "deno" to start the completion process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ means we will never make a backwards-incompatible change within a major version 
 
 ## [Unreleased]
 
-...Nothing yet!
+- Handles common typo `deno` as `done` (by @itsthejoker)
 
 ## v3.3.0 (2017-11-22)
 

--- a/tor/core/inbox.py
+++ b/tor/core/inbox.py
@@ -77,30 +77,33 @@ def process_reply(reply, config):
             reply.mark_read()
             return
 
-        if 'i accept' in reply.body.lower():
+        r_body = reply.body.lower()  # cache that thing
+
+        if 'i accept' in r_body:
             process_coc(reply, config)
             reply.mark_read()
             return
 
-        if 'claim' in reply.body.lower():
+        if 'claim' in r_body:
             process_claim(reply, config)
             reply.mark_read()
             return
 
         if (
-            'done' in reply.body.lower() or
-            'deno' in reply.body.lower()  # we <3 u/Lornescri
+            'done' in r_body or
+            'deno' in r_body  # we <3 u/Lornescri
         ):
-            process_done(reply, config)
+            alt_text = True if 'done' not in r_body else False
+            process_done(reply, config, alt_text_trigger=alt_text)
             reply.mark_read()
             return
 
-        if 'thank' in reply.body.lower():  # trigger on "thanks" and "thank you"
+        if 'thank' in r_body:  # trigger on "thanks" and "thank you"
             process_thanks(reply, config)
             reply.mark_read()
             return
 
-        if '!override' in reply.body.lower():
+        if '!override' in r_body:
             process_override(reply, config)
             reply.mark_read()
             return

--- a/tor/core/inbox.py
+++ b/tor/core/inbox.py
@@ -87,7 +87,10 @@ def process_reply(reply, config):
             reply.mark_read()
             return
 
-        if 'done' in reply.body.lower():
+        if (
+            'done' in reply.body.lower() or
+            'deno' in reply.body.lower()  # we <3 u/Lornescri
+        ):
             process_done(reply, config)
             reply.mark_read()
             return

--- a/tor/core/user_interaction.py
+++ b/tor/core/user_interaction.py
@@ -111,7 +111,7 @@ def process_claim(post, config):
         raise  # Re-raise exception if not
 
 
-def process_done(post, config, override=False):
+def process_done(post, config, override=False, alt_text_trigger=False):
     """
     Handles comments where the user says they've completed a post.
     Also includes a basic decision tree to enable verification of
@@ -166,7 +166,13 @@ def process_done(post, config, override=False):
                 logging.info('Moderator override starting!')
             # noinspection PyUnresolvedReferences
             try:
-                post.reply(_(done_completed_transcript))
+                if alt_text_trigger:
+                    post.reply(_(
+                        'I think you meant `done`, so here we go!\n\n' +
+                        done_completed_transcript
+                    ))
+                else:
+                    post.reply(_(done_completed_transcript))
                 update_user_flair(post, config)
                 logging.info(
                     f'Post {top_parent.fullname} completed by {post.author}!'


### PR DESCRIPTION
Of all the various typos we see, "deno" is by far the most popular way to butcher "done". This minor update allows this to process as normal.