### PR TITLE
History checker blows up on pinned submissions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -81,6 +81,7 @@ setup(
     install_requires=[
         'tor_core',
         'sh',
+        'praw',
     ],
     dependency_links=[
         'git+https://github.com/GrafeasGroup/tor_core.git@master#egg=tor_core-0',

--- a/tor/core/validation.py
+++ b/tor/core/validation.py
@@ -1,6 +1,7 @@
 from tor.strings.urls import ToR_link
 from tor_core.helpers import get_parent_post_id
 from tor_core.helpers import send_to_slack
+from praw.models import Comment
 
 
 def _author_check(original_post, claimant_post):
@@ -77,7 +78,10 @@ def _author_history_check(post, config):
     :param config: the global config object.
     :return: True if the post is found in the history, False if not.
     """
-    for history_post in post.author.new(limit=5):
+    for history_post in post.author.new(limit=10):
+        if not isinstance(history_post, Comment):
+            continue
+
         if (
             history_post.is_root and
             _footer_check(history_post, config) and


### PR DESCRIPTION
If a user actually uses their feed for more than just comment history (it's possible nowadays to have your own subreddit-like experience on your user profile), we skip it. This became necessary when we wouldn't respond to `done` with the new history checker functionality.