### PR TITLE
Fixes video id of `None` errors from YouTube

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ means we will never make a backwards-incompatible change within a major version 
 ## Unreleased (2018-1-15)
 
 - Verbiage updates and other message improvements (by @itsthejoker)
+- Fixes issue with YouTube transcription requested for video id `None` (by @thelonelyghost)
 
 ## v3.4.0 (2017-12-11)
 

--- a/tor/helpers/youtube.py
+++ b/tor/helpers/youtube.py
@@ -54,10 +54,13 @@ def get_yt_transcript(url, yt_transcript_url=youtube_transcription_url):
         if there's an error.
     """
     try:
+        video_id = get_yt_video_id(url)
+        if not video_id:
+            # If not able to get video id, no point in continuing
+            return None
+
         result = requests.get(
-            yt_transcript_url.format(
-                get_yt_video_id(url)
-            )
+            yt_transcript_url.format(video_id)
         )
         result.raise_for_status()
         if result.text.startswith(


### PR DESCRIPTION
This should prevent us from sending off a transcription request if the video id wasn't able to be gleaned from the URL. If nothing else, we can do logging of the url we weren't able to decode in order to refine the video id extraction method, but 🤷‍♂️ 