### PR TITLE
Change history validation to only look for comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ means we will never make a backwards-incompatible change within a major version 
 
 - Verbiage updates and other message improvements (by @itsthejoker)
 - Fixes issue with YouTube transcription requested for video id `None` (by @thelonelyghost)
+- Fixes history check on users who have submissions stickied to their profile (by @arfie)
 
 ## v3.4.0 (2017-12-11)
 

--- a/tor/core/validation.py
+++ b/tor/core/validation.py
@@ -78,7 +78,7 @@ def _author_history_check(post, config):
     :param config: the global config object.
     :return: True if the post is found in the history, False if not.
     """
-    for history_post in post.author.new(limit=10):
+    for history_post in post.author.comments.new(limit=10):
         if not isinstance(history_post, Comment):
             continue
 

--- a/tor/core/validation.py
+++ b/tor/core/validation.py
@@ -1,7 +1,6 @@
 from tor.strings.urls import ToR_link
 from tor_core.helpers import get_parent_post_id
 from tor_core.helpers import send_to_slack
-from praw.models import Comment
 
 
 def _author_check(original_post, claimant_post):
@@ -79,9 +78,6 @@ def _author_history_check(post, config):
     :return: True if the post is found in the history, False if not.
     """
     for history_post in post.author.comments.new(limit=10):
-        if not isinstance(history_post, Comment):
-            continue
-
         if (
             history_post.is_root and
             _footer_check(history_post, config) and


### PR DESCRIPTION
So apparently the history validation doesn't work properly when someone has submissions stickied to their profile. I was unable to replicate this, but it should be fixed anyway by this.