### PR TITLE
updated for modchat

### DIFF
--- a/tor/core/admin_commands.py
+++ b/tor/core/admin_commands.py
@@ -6,7 +6,7 @@ from praw.exceptions import ClientException as RedditClientException
 # noinspection PyProtectedMember
 from tor_core.helpers import _
 from tor_core.helpers import clean_id
-from tor_core.helpers import send_to_slack
+from tor_core.helpers import send_to_modchat
 from tor_core.initialize import initialize
 
 from tor.core.user_interaction import process_done
@@ -72,9 +72,9 @@ def process_command(reply, config):
                 f" command"
             )
             username = reply.author.name
-            send_to_slack(
+            send_to_modchat(
                 f":banhammer: Someone did something bad! "
-                f"<https://reddit.com/user/{username}|u/{username}> tried to "
+                f"[u/{username}](https://reddit.com/user/{username}) tried to "
                 f"run {requested_command}!", config
             )
 

--- a/tor/core/inbox.py
+++ b/tor/core/inbox.py
@@ -3,7 +3,7 @@ import re
 
 from praw.exceptions import ClientException as RedditClientException
 from praw.models import Comment as RedditComment
-from tor_core.helpers import send_to_slack
+from tor_core.helpers import send_to_modchat
 
 from tor.core.admin_commands import process_override
 from tor.core.admin_commands import process_command
@@ -24,9 +24,9 @@ MOD_SUPPORT_PHRASES = [
 def forward_to_slack(item, config):
     username = item.author.name
 
-    send_to_slack(
+    send_to_modchat(
         f'Unhandled message by '
-        f'<https://reddit.com/user/{username}|u/{username}> -- '
+        f'[u/{username}](https://reddit.com/user/{username}) -- '
         f'*{item.subject}*:\n{item.body}', config
     )
     logging.info(
@@ -61,10 +61,10 @@ def process_mod_intervention(post, config):
     # Wrap each phrase in double-quotes (") and commas in between
     phrases = '"' + '", "'.join(phrases) + '"'
 
-    send_to_slack(
+    send_to_modchat(
         f':rotating_light::rotating_light: Mod Intervention Needed '
         f':rotating_light::rotating_light: '
-        f'\n\nDetected use of {phrases} <{post.submission.shortlink}>',
+        f'\n\nDetected use of {phrases} {post.submission.shortlink}',
         config
     )
 
@@ -138,7 +138,7 @@ def check_inbox(config):
         # Very rarely we may actually get a message from Reddit itself.
         # In this case, there will be no author attribute.
         if item.author is None:
-            send_to_slack(
+            send_to_modchat(
                 f'We received a message without an author. Subject: '
                 f'{item.subject}', config
             )

--- a/tor/core/user_interaction.py
+++ b/tor/core/user_interaction.py
@@ -6,7 +6,7 @@ import praw
 from tor_core.helpers import _
 from tor_core.helpers import get_parent_post_id
 from tor_core.helpers import get_wiki_page
-from tor_core.helpers import send_to_slack
+from tor_core.helpers import send_to_modchat
 
 from tor.core.validation import verified_posted_transcript
 from tor.helpers.flair import flair
@@ -49,8 +49,8 @@ def process_coc(post, config):
     # Have they already been added? If 0, then just act like they said `claim`
     # instead. If they're actually new, then send a message to slack.
     if result == 1:
-        send_to_slack(
-            f'<http://www.reddit.com/u/{post.author.name}|u/{post.author.name}>'
+        send_to_modchat(
+            f'[u/{post.author.name}](http://www.reddit.com/u/{post.author.name})'
             f' has just accepted the CoC!', config
         )
     process_claim(post, config)

--- a/tor/core/validation.py
+++ b/tor/core/validation.py
@@ -1,6 +1,6 @@
 from tor.strings.urls import ToR_link
 from tor_core.helpers import get_parent_post_id
-from tor_core.helpers import send_to_slack
+from tor_core.helpers import send_to_modchat
 from praw.models import Comment
 
 
@@ -126,7 +126,7 @@ def verified_posted_transcript(post, config):
 
     # Did their transcript get flagged by the spam filter? Check their history.
     if _author_history_check(post, config):
-        send_to_slack(
+        send_to_modchat(
             f'Found removed post: {post.submission.shortlink}',
             config,
             channel='#removed_posts'

--- a/tor/helpers/flair.py
+++ b/tor/helpers/flair.py
@@ -2,7 +2,7 @@ import logging
 
 from tor_core.helpers import clean_id
 from tor_core.helpers import flair
-from tor_core.helpers import send_to_slack
+from tor_core.helpers import send_to_modchat
 
 
 def flair_post(post, text):
@@ -141,7 +141,7 @@ def set_meta_flair_on_other_posts(config):
                 f'Meta. '
             )
             flair_post(post, flair.meta)
-            send_to_slack(
-                f'New meta post: <{post.url}|{post.fullname}>',
+            send_to_modchat(
+                f'New meta post: [{post.title}]({post.url})',
                 config
             )


### PR DESCRIPTION
This PR removes slack-specific language and replaces it with the more generic "modchat". This _must_ be merged with the corresponding PR to tor_core.