### PR TITLE
Change Check Submissions to use threads

### DIFF
--- a/tor/core/posts.py
+++ b/tor/core/posts.py
@@ -17,30 +17,6 @@ from tor.strings.posts import rules_comment
 from tor.strings.posts import yt_already_has_transcripts
 
 
-def check_submissions(subreddit, config):
-    """
-    Loops through all of the subreddits that have opted in and pulls
-    the 10 newest submissions. It checks the domain of the submission
-    against the domain lists and hands off the post to process_post()
-    for formatting and posting on ToR.
-
-    :param subreddit: String. A valid subreddit name.
-    :param config: the config object.
-    :return: None.
-    """
-
-    sr = config.r.subreddit(subreddit).new(limit=10)
-
-    for post in sr:
-        if (
-            post.domain in config.image_domains or
-            post.domain in config.audio_domains or
-            post.domain in config.video_domains or
-            subreddit in config.subreddits_domain_filter_bypass
-        ):
-            process_post(post, config)
-
-
 def process_post(new_post, config):
     """
     After a valid post has been discovered, this handles the formatting
@@ -51,51 +27,50 @@ def process_post(new_post, config):
     :return: None.
     """
 
-    subreddit = new_post.subreddit
-
-    if subreddit.display_name in config.upvote_filter_subs:
+    if new_post['subreddit'] in config.upvote_filter_subs:
         # ignore posts if they don't meet the threshold for karma and the sub
         # is in our list of upvoted filtered ones
-        if new_post.ups < config.upvote_filter_subs[subreddit.display_name]:
+        if new_post['ups'] < config.upvote_filter_subs[new_post['subreddit']]:
             return
 
-    if not is_valid(new_post.fullname, config):
-        logging.debug(id_already_handled_in_db.format(new_post.fullname))
+    if not is_valid(new_post['name'], config):
+        logging.debug(id_already_handled_in_db.format(new_post['name']))
         return
 
-    if new_post.archived:
+    if new_post['archived']:
         return
 
-    if new_post.author is None:
+    if new_post['author'] is None:
         # we don't want to handle deleted posts, that's just silly
         return
 
     logging.info(
-        f'Posting call for transcription on ID {new_post.fullname} posted by '
-        f'{new_post.author.name} '
+        f'Posting call for transcription on ID {new_post["name"]} posted by '
+        f'{new_post["author"]}'
     )
 
-    if new_post.domain in config.image_domains:
+    if new_post['domain'] in config.image_domains:
         content_type = 'image'
         content_format = config.image_formatting
 
-    elif new_post.domain in config.audio_domains:
+    elif new_post['domain'] in config.audio_domains:
         content_type = 'audio'
         content_format = config.audio_formatting
 
-    elif new_post.domain in config.video_domains:
-        if 'youtu' in new_post.domain:
-            if not valid_youtube_video(new_post.url):
-                add_complete_post_id(new_post.fullname, config)
+    elif new_post['domain'] in config.video_domains:
+        if 'youtu' in new_post['domain']:
+            if not valid_youtube_video(new_post['url']):
+                add_complete_post_id(new_post['name'], config)
                 return
-            if get_yt_transcript(new_post.url):
-                new_post.reply(_(
+            if get_yt_transcript(new_post['url']):
+                np = config.r.submission(id=new_post['name'])
+                np.reply(_(
                     yt_already_has_transcripts
                 ))
-                add_complete_post_id(new_post.fullname, config)
+                add_complete_post_id(new_post['name'], config)
                 logging.info(
-                    f'Found YouTube video, {get_yt_video_id(new_post.url)}, '
-                    f'with good transcripts.'
+                    f'Found YouTube video, {get_yt_video_id(new_post["url"])},'
+                    f' with good transcripts.'
                 )
                 return
         content_type = 'video'
@@ -107,7 +82,7 @@ def process_post(new_post, config):
 
     # Truncate a post title if it exceeds 250 characters, so the added
     # formatting still fits in Reddit's 300 char limit for post titles
-    post_title = new_post.title
+    post_title = new_post['title']
     max_title_length = 250
     if len(post_title) > max_title_length:
         post_title = post_title[:max_title_length - 3] + '...'
@@ -116,11 +91,11 @@ def process_post(new_post, config):
     try:
         result = config.tor.submit(
             title=discovered_submit_title.format(
-                sub=new_post.subreddit.display_name,
+                sub=new_post['subreddit'],
                 type=content_type.title(),
                 title=post_title
             ),
-            url=reddit_url.format(new_post.permalink)
+            url=reddit_url.format(new_post['permalink'])
         )
         result.reply(
             _(
@@ -133,22 +108,24 @@ def process_post(new_post, config):
         )
         flair_post(result, flair.unclaimed)
 
-        add_complete_post_id(new_post.fullname, config)
+        add_complete_post_id(new_post['name'], config)
         config.redis.incr('total_posted', amount=1)
 
         if config.OCR and content_type == 'image':
             # hook for OCR bot; in order to avoid race conditions, we add the
             # key / value pair that the bot isn't looking for before adding
             # to the set that it's monitoring.
-            config.redis.set(new_post.fullname, result.fullname)
-            config.redis.rpush('ocr_ids', new_post.fullname)
+            config.redis.set(new_post['name'], result.fullname)
+            config.redis.rpush('ocr_ids', new_post['name'])
 
         config.redis.incr('total_new', amount=1)
 
-    # I need to figure out what errors can happen here
+    # The only errors that happen here are on Reddit's side -- pretty much
+    # exclusively 503s and 403s that arbitrarily resolve themselves. A missed
+    # post or two is not the end of the world.
     except Exception as e:
         logging.error(
-            f'{e} - unable to post content.\nID: {new_post.fullname}\n '
-            f'Title: {new_post.title}\n Subreddit: '
-            f'{new_post.subreddit.display_name} '
+            f'{e} - unable to post content.\nID: {new_post["name"]}\n '
+            f'Title: {new_post["title"]}\n Subreddit: '
+            f'{new_post["subreddit"]}'
         )

--- a/tor/helpers/threaded_worker.py
+++ b/tor/helpers/threaded_worker.py
@@ -1,0 +1,116 @@
+# After a lengthy discussion with @thelonelyghost, it became apparent that we're
+# fully expecting to completely throw away this codebase when we finish the
+# rewrite for celery. Therefore, ugly-ass hacks are allowed in the name of
+# making the current bots faster if at all possible. Is it maintainable?
+# Absolutely not, but that's a conscious decision on our part. Feast your eyes
+# upon the ugliness... and know that we are sorry.
+
+import logging
+import random
+import string
+from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import as_completed
+
+import requests
+from typing import Dict
+from typing import List
+
+from tor.core.posts import process_post
+
+
+def get_subreddit_posts(sub: str) -> [List, None]:
+
+    def generate_user_agent() -> str:
+        """
+        Reddit routinely blocks / throttles common user agents. The easiest way
+        to deal with that is to (nicely) generate a partially unique user-agent
+        in an easy-to-follow pattern in case they decide that they do want to
+        block us for this.
+        :return: A complete user agent string.
+        """
+        return (
+            '0.1.0.ToR.Client.Thread.{}.ID.{} (contact u/itsthejoker)'.format(
+                random.randrange(0, 30),
+                ''.join(
+                    [random.choice(string.ascii_lowercase) for _ in range(6)]
+                ),
+            )
+        )
+
+    def parse_json_posts(posts: Dict) -> List:
+        trimmed_links = list()
+        number_of_posts = 10
+        posts_raw = posts['data']['children']
+        posts_raw = posts_raw[:number_of_posts]  # cut the list from 25 to 10
+        for item in posts_raw:
+            # there are only two top level keys here; kind (comment / post) and
+            # data. No reason to keep the kind because we're only pulling posts.
+            item = item['data']
+            if not item['is_self']:
+                trimmed_links.append({
+                    'subreddit': item['subreddit'],
+                    'name': item['name'],  # remember, this is the ID: t3_8swl2n
+                    'title': item['title'],
+                    'permalink': item['permalink'],
+                    'is_nsfw': item['over_18'],
+                    'domain': item['domain'],
+                    'ups': item['ups'],
+                    'locked': item['locked'],
+                    'archived': item['archived'],
+                    'author': item.get('author', None)
+                })
+        return trimmed_links
+
+    headers = {
+        'User-Agent': generate_user_agent()
+    }
+    url = 'https://www.reddit.com/r/{}/new/.json'.format(sub)
+    result = requests.get(url, headers=headers).json()
+    # we have two states here: one has the data we want and the other is an
+    # error state. The error state looks like this:
+    # {'message': 'Too Many Requests', 'error': 429}
+
+    if result.get('error', None):
+        logging.warning('hit error state for {}'.format(sub))
+        return []
+    return parse_json_posts(result)
+
+
+def threaded_check_submissions(config):
+    """
+    Single threaded PRAW performance:
+    finished in 56.75446701049805s
+
+    Single threaded json performance:
+    finished in 16.70485234260559s
+
+    multi-threaded json performance:
+    finished in 1.3632569313049316s
+    """
+    subreddits = config.subreddits_to_check
+
+    total_posts = list()
+    # by not specifying a maximum number of threads, ThreadPoolExecutor will
+    # grab the CPU count of the current machine and multiply it by 5, allowing
+    # us to keep sane limits wherever we're running.
+    with ThreadPoolExecutor() as executor:
+        jobs = list()
+        for sub in subreddits:
+            jobs.append(executor.submit(get_subreddit_posts, sub))
+        for f in as_completed(jobs):
+            try:
+                data = f.result()
+                total_posts += data
+            except Exception as exc:
+                print('an exception was generated: {}'.format(exc))
+            else:
+                print('retrieved {} posts'.format(len(data)))
+
+    for item in total_posts:
+        if (
+            item['domain'] in config.image_domains or
+            item['domain'] in config.audio_domains or
+            item['domain'] in config.video_domains or
+            item['subreddit'] in config.subreddits_domain_filter_bypass
+        ):
+            process_post(item, config)

--- a/tor/main.py
+++ b/tor/main.py
@@ -8,6 +8,7 @@ from tor_core.initialize import build_bot
 from tor import __version__
 from tor.core.inbox import check_inbox
 from tor.core.posts import check_submissions
+from tor.helpers.threaded_worker import threaded_check_submissions
 from tor.helpers.flair import set_meta_flair_on_other_posts
 
 # Patreon Dedications:
@@ -48,8 +49,7 @@ def run(config):
     """
     check_inbox(config)
 
-    for sub in config.subreddits_to_check:
-        check_submissions(sub, config)
+    threaded_check_submissions(config)
 
     set_meta_flair_on_other_posts(config)
 


### PR DESCRIPTION
This PR completely rebuilds the existing system that checks for new posts. Currently, running through all of our partner subreddits and running everything through the filters takes around 58 seconds.

This PR takes that down to ~1.6-2.3 seconds.

I've tested the threading section extensively, but `process_post` needs more manual testing. I am exhausted, so I'm putting this PR up here so I can hit the hay and work on this later.

The goal is to get this tested, reviewed, and merged before the Clear the Queue event on the 23rd.