### PR TITLE
Add in some delay for checking for new posts

### DIFF
--- a/tor/helpers/threaded_worker.py
+++ b/tor/helpers/threaded_worker.py
@@ -8,6 +8,8 @@
 import logging
 import random
 import string
+from datetime import timedelta
+from datetime import datetime
 from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures import as_completed
 
@@ -95,6 +97,13 @@ def get_subreddit_posts(sub: str) -> [List, None]:
     return parse_json_posts(result)
 
 
+def is_time_to_scan(config) -> bool:
+    if datetime.now() > config.last_post_scan_time + timedelta(seconds=45):
+        config.last_post_scan_time = datetime.now()
+        return True
+    return False
+
+
 def threaded_check_submissions(config):
     """
     Single threaded PRAW performance:
@@ -106,6 +115,10 @@ def threaded_check_submissions(config):
     multi-threaded json performance:
     finished in 1.3632569313049316s
     """
+
+    if not is_time_to_scan(config):
+        return
+
     subreddits = config.subreddits_to_check
 
     total_posts = list()

--- a/tor/helpers/threaded_worker.py
+++ b/tor/helpers/threaded_worker.py
@@ -98,10 +98,7 @@ def get_subreddit_posts(sub: str) -> [List, None]:
 
 
 def is_time_to_scan(config) -> bool:
-    if datetime.now() > config.last_post_scan_time + timedelta(seconds=45):
-        config.last_post_scan_time = datetime.now()
-        return True
-    return False
+    return datetime.now() > config.last_post_scan_time + timedelta(seconds=45)
 
 
 def threaded_check_submissions(config):
@@ -117,7 +114,11 @@ def threaded_check_submissions(config):
     """
 
     if not is_time_to_scan(config):
+        # we're still within the defined time window from the last time we
+        # looked for new posts. We'll try again later.
         return
+
+    config.last_post_scan_time = datetime.now()
 
     subreddits = config.subreddits_to_check
 


### PR DESCRIPTION
We sped up checking for new posts so much that we're kind of hammering Reddit's API right now. This change makes it so that we only check for new posts once every 45 seconds and has a matching PR in tor_core.