### PR TITLE
Adds GitLab CI integration for linting and pytest

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,38 @@
+---
+image: 'python:3.7-rc-alpine'
+
+variables:
+  GIT_DEPTH: "1"
+
+stages:
+  - linting
+  - tests
+
+black:
+  stage: linting
+  before_script:
+    - 'pip3 install black'
+  script:
+    - 'black --check setup.py tor'
+
+flake8:
+  stage: linting
+  before_script:
+    - 'pip3 install flake8'
+  script:
+    - 'flake8 tor'
+
+pylint:
+  stage: linting
+  before_script:
+    - 'pip3 install pylint'
+  script:
+    - 'pylint tor'
+
+pytest:
+  stage: tests
+  before_script:
+    - 'pip3 install -e .[dev]'
+  script:
+    - 'pytest'
+...


### PR DESCRIPTION
I'm totally open to suggestions, but it looks like this would make it quick and easy to just use GitLab's CI component, even to report back in on GitHub.

Some things to note are that all of the linting or static analysis tools (`black`, `pylint`, and `flake8`) are running without configuration files. That can be changed pretty easily.

Additionally, this runs under Python 3.7.0b5 only because the released version of Python 3.7.0 is not yet available as a Docker image, per docker-library/python#297.

Given that this is run on a Docker container, one can troubleshoot an issue locally using the publicly available image. Much nicer than Travis or Circle CI!