### PR TITLE
Removed check for incomplete posts

### DIFF
--- a/tor/helpers/reddit_ids.py
+++ b/tor/helpers/reddit_ids.py
@@ -1,10 +1,9 @@
-import logging
-
-
-def add_complete_post_id(post_id, config):
+def add_complete_post_id(
+    post_id: int, config, return_result: bool = False
+) -> [None, bool]:
     """
-    Adds the post id to the complete_post_ids set in Redis. This is used
-    to make sure that we didn't break halfway through working on this post.
+    Adds the post id to the complete_post_ids set in Redis. This is used to keep
+    track of which posts we've worked on and which ones we haven't.
 
     NOTE: This does not keep track of *transcribed* posts. This is only
     used to track the actual posting process, from grabbing new posts
@@ -12,44 +11,29 @@ def add_complete_post_id(post_id, config):
 
     :param post_id: string. The comment / post ID.
     :param config: the global config dict.
-    :return: None.
+    :param return_result: Do we want to get the result back? Most of the time
+        we don't care.
     """
-    config.redis.sadd('complete_post_ids', post_id)
+    result = config.redis.sadd("complete_post_ids", post_id)
+    if return_result:
+        return True if result == 1 else False
 
 
 def is_valid(post_id, config):
     """
     Returns true or false based on whether the parent id is in a set of IDs.
     It determines this by attempting to insert the value into the DB and
-    returning the result. If the result is already in the set, we check the
-    completed id set as well to make sure that it's actually been done. If
-    it's in the post_ids set and *not* the complete_post_ids set, we assume
-    something went horribly wrong and we try again.
+    returning the result. If the result is already in the set, return False,
+    since we know we've already worked on that post. If we successfully inserted
+    it, then return True so we can process it.
 
     :param post_id: string. The comment / post ID.
     :param config: the global config object.
     :return: True if the ID is successfully inserted into the set; False if
         it's already there.
     """
-    result = config.redis.sadd('post_ids', post_id)
 
-    if result == 1:
-        # the post id was submitted successfully and it's good to work on.
-        return True
-
-    else:
-        # The post is already in post_ids, which is triggered when we start
-        # the process. Let's see if we ever completed it.
-        member = config.redis.sismember('complete_post_ids', post_id)
-        if member != 1:
-            # It's in post_ids, which means we started it, but it's not
-            # in complete_post_ids, which means we never finished it for
-            # some reason. Let's try it again.
-            logging.warning(f'Incomplete post found! ID: {post_id}')
-            return True
-
-        else:
-            # it *is* in complete_post_ids, which means we've already
-            # worked on it. Therefore, the post generally is not valid
-            # to work on because it's already been successfully completed.
-            return False
+    # if we get back a True, then we return True because the post was submitted
+    # successfully and it's good to work on. If the insert fails, then we
+    # want to return a False because we cannot work on that post again.
+    return add_complete_post_id(post_id, config, return_result=True)


### PR DESCRIPTION
The incomplete post check, while great in theory, causes more problems than it's worth because Reddit doesn't like it when we retry posting actions. This causes the bot to continue to try resubmitting the same job over and over and having it continually fail, sending the bot into a never-ending failure state.

```
Jul 09 03:27:26 tor_moderator[2972]: WARNING | is_valid | Incomplete post found! ID: t3_8x6jp2
Jul 09 03:27:26 tor_moderator[2972]: INFO | process_post | Posting call for transcription on ID t3_8x6jp2 posted by needco
Jul 09 03:27:26 tor_moderator[2972]: WARNING | run_until_dead | received 403 HTTP response - Issue communicating with Reddit. Sleeping for 60s!
Jul 09 03:28:30 tor_moderator[2972]: WARNING | is_valid | Incomplete post found! ID: t3_8x6jp2
Jul 09 03:28:30 tor_moderator[2972]: INFO | process_post | Posting call for transcription on ID t3_8x6jp2 posted by needco
Jul 09 03:28:30 tor_moderator[2972]: WARNING | run_until_dead | received 403 HTTP response - Issue communicating with Reddit. Sleeping for 60s!
```
...endlessly, until I manually add that post ID to Redis so that it can move on. This PR removes the aforementioned check.

Notably, this PR is needed because I've done this manual fix twice today.