### PR TITLE
Update slack messages a bit

### DIFF
--- a/tor/core/inbox.py
+++ b/tor/core/inbox.py
@@ -160,8 +160,8 @@ def check_inbox(config):
         # In this case, there will be no author attribute.
         if item.author is None:
             send_to_modchat(
-                f'We received a message without an author. Subject: '
-                f'{item.subject}', config
+                f'We received a message without an author -- '
+                f'*{item.subject}*:\n{item.body}', config
             )
             item.mark_read()
 

--- a/tor/helpers/flair.py
+++ b/tor/helpers/flair.py
@@ -157,6 +157,6 @@ def set_meta_flair_on_other_posts(config):
             )
             flair_post(post, flair.meta)
             send_to_modchat(
-                f'New meta post: <{post.url}|{post.title}>)',
+                f'New meta post: <{post.shortlink}|{post.title}>',
                 config
             )


### PR DESCRIPTION
Mainly changes the meta post notification to actually link to the post rather than the attached URL. Also includes the body of messages without an author, just like with unhandled messages.