### PR TITLE
RFC: Add Code of Merit, modified for GG

### DIFF
--- a/CODE_OF_MERIT.md
+++ b/CODE_OF_MERIT.md
@@ -1,0 +1,42 @@
+# Code of Merit
+
+> *"Intellectual freedom can exist only where two essential conditions are met: first, that all individuals have the right to hold any belief on any subject and to convey their ideas in any form they deem appropriate, and second, that society makes an equal commitment to the right of unrestricted access to information and ideas regardless of the communication medium used, the content of work, and the viewpoints of both the author and the receiver of information."* - Intellectual Freedom Manual, 7th edition
+
+
+**1.** The project creators, lead developers, core team, constitute the managing members of the project and have final say in every decision of the project, technical or otherwise, including overruling previous decisions. There are no limitations to this decisional power.
+
+**2.** Contributions are an expected result of your membership on the project. Don’t expect others to do your work or help you with your work forever.
+
+**3.** All members have the same opportunities to seek any challenge they want within the project.
+
+**4.** Authority or position in the project will be proportional to the accrued contribution. Seniority must be earned.
+
+**5.** Software is evolutive: the better implementations must supersede lesser implementations. Technical advantage is the primary evaluation metric.
+
+**6.** This is a space for technical prowess; topics outside of the project will not be tolerated.
+
+**7.** Non technical conflicts will be discussed in a separate space. Disruption of the project will not be allowed.
+
+**8.** Individual characteristics, including but not limited to, body, sex, sexual preference, race, language, religion, nationality, or political preferences are irrelevant in the scope of the project and will not be taken into account concerning your value or that of your contribution to the project.
+
+**9.** Discuss or debate the idea, not the person.
+
+**10.** There is no room for ambiguity: Ambiguity will be met with questioning; further ambiguity will be met with silence. It is the responsibility of the originator to provide requested context.
+
+**11.** If something is illegal outside the scope of the project, it is illegal in the scope of the project. This Code of Merit does not take precedence over governing law.
+
+**12.** This Code of Merit governs the technical procedures of the project not the activities outside of it.
+
+**13.** Participation on the project equates to agreement of this Code of Merit.
+
+**14.** No objectives beyond the stated objectives of this project are relevant to the project. Any intent to deviate the project from its original purpose of existence will constitute grounds for remedial action which may include expulsion from the project.
+
+**15.** We distinguish between our personal convictions and professional duties and do not allow our personal beliefs to interfere with fair representation of the aims of our institutions or the ability to contribute to shared endeavors.
+
+tl;dr: We support everyone and encourage everyone to contribute. However, if you are a shitbird to other contributors during your work on the project, or if you're found to be inciting violence with your work (must have IRREFUTABLE PROOF for this), then you'll be kicked out of the project.
+
+---
+
+This document is adapted from the Code of Merit (<strike>http://code-of-merit.org</strike>), version 1.0.  
+Point 15 is adapted from the American Librarian Association (ALA)'s Code of Ethics (http://www.ala.org/tools/ethics).  
+Originally retrieved from https://github.com/DuckHP/Code-of-Merit, 2019-03-19. Last updated: 2019-03-19.

--- a/CODE_OF_MERIT.md
+++ b/CODE_OF_MERIT.md
@@ -33,7 +33,7 @@
 
 **15.** We distinguish between our personal convictions and professional duties and do not allow our personal beliefs to interfere with fair representation of the aims of our institutions or the ability to contribute to shared endeavors.
 
-tl;dr: We support everyone and encourage everyone to contribute. However, if you are a shitbird to other contributors during your work on the project, or if you're found to be inciting violence with your work (must have IRREFUTABLE PROOF for this), then you'll be kicked out of the project.
+tl;dr: We support everyone and encourage everyone to contribute. However, if you are a shitbird to other contributors during your work on the project, or if you're found to be inciting violence with your work, then you'll be kicked out of the project.
 
 ---
 


### PR DESCRIPTION
One of the most important aspects of our work, both as an organization and in the codebases, is to be accepting of different viewpoints which can further our mutual mission. This naturally leads us in pursuit of some guidelines to govern contributor behavior and act as a higher set of rules with which we should use to resolve conflict. 

While a large number of projects include the Contributor Covenant as a guideline for contributor behavior, there are concerning issues that lead to multiple interpretations of the document and a lack of defined boundaries -- if a code of conduct is open to interpretation, then it is not strict enough.

The below is a modified version of the Code of Merit, slightly updated with an addition from the American Librarian Association (ALA), whose ethics guidelines have been well-understood and accepted for the last eighty years.

This PR will remain open for at least one (1) week, closing on 2019-03-26 if no conversation appears. Otherwise it will close when majority of contributors who wish to weigh in agree.

Signed-off-by: Joe Kaufeld <joe@grafeas.org>