### PR TITLE
documentation update and extend detecting transcriptions in the wrong place

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Fixes typo in capitalization of one of the user-facing messages
 - Fixes flair colors to level up at (e.g.) 50, not 51 (#96)
+- Extend check for transcription in the right place to handle New Reddit editor (credit @itsthejoker)
 
 ## [3.11.0] - 2019-06-17
 
@@ -14,9 +15,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [3.10.1] - 2019-06-17
 
-- Fixes history check on users who have submissions stickied to their profile (by @arfie)
-- Fixes youtube auto-transcription attempts erroring out when unable to detect the video id (by @thelonelyghost)
-- Adds clearer indicator for post type to rules comment (by @itsthejoker)
+- Fixes history check on users who have submissions stickied to their profile (credit @arfie)
+- Fixes youtube auto-transcription attempts erroring out when unable to detect the video id (credit @thelonelyghost)
+- Adds clearer indicator for post type to rules comment (credit @itsthejoker)
 
 ## [3.10.0] - 2019-06-16
 

--- a/tor/core/inbox.py
+++ b/tor/core/inbox.py
@@ -83,9 +83,10 @@ def process_reply(reply, cfg):
 
         if (
             'image transcription' in r_body or
-            validation._footer_check(reply, cfg)
+            validation._footer_check(reply, cfg) or
+            validation._footer_check(reply, cfg, new_reddit=True)
         ):
-            process_wrong_post_location(reply)
+            process_wrong_post_location(reply, cfg)
             reply.mark_read()
             return
 
@@ -109,7 +110,8 @@ def process_reply(reply, cfg):
 
         if (
             'done' in r_body or
-            'deno' in r_body  # we <3 u/Lornescri
+            'deno' in r_body or  # we <3 u/Lornescri
+            'doen' in r_body
         ):
             alt_text = True if 'done' not in r_body else False
             process_done(reply, cfg, alt_text_trigger=alt_text)

--- a/tor/core/user_interaction.py
+++ b/tor/core/user_interaction.py
@@ -9,6 +9,7 @@ from tor.core.helpers import (_, clean_id, get_parent_post_id, get_wiki_page,
 from tor.core.strings import reddit_url
 from tor.core.users import User
 from tor.core.validation import verified_posted_transcript
+from tor.core.validation import _footer_check
 from tor.helpers.flair import flair, flair_post, update_user_flair
 from tor.helpers.reddit_ids import is_removed
 from tor.strings import translation
@@ -323,8 +324,10 @@ def process_thanks(post, cfg):
         raise
 
 
-def process_wrong_post_location(post):
+def process_wrong_post_location(post, cfg):
     transcript_on_tor_post = i18n['responses']['general']['transcript_on_tor_post']
+    if _footer_check(post, cfg, new_reddit=True):
+        transcript_on_tor_post += i18n['responses']['general']['new_reddit_transcript']
     try:
         post.reply(_(transcript_on_tor_post))
     except praw.exceptions.APIException:

--- a/tor/core/validation.py
+++ b/tor/core/validation.py
@@ -8,7 +8,7 @@ def _author_check(original_post, claimant_post):
     return original_post.author == claimant_post.author
 
 
-def _footer_check(reply, cfg, tor_link=None):
+def _footer_check(reply, cfg, tor_link=None, new_reddit=False):
     """
     Is the footer in there?
 
@@ -16,12 +16,19 @@ def _footer_check(reply, cfg, tor_link=None):
         it.
     :param cfg: the global config object.
     :param tor_link: String; the magical url key.
+    :param new_reddit: Bool; whether to check for the markdown (old reddit)
+        footer or the WYSIWYG (new reddit) malformed footer.
     :return: True / None.
     """
     if tor_link is None:
         tor_link = i18n['urls']['ToR_link']
+
     if cfg.perform_header_check:
-        return tor_link in reply.body and '&#32;' in reply.body
+        if new_reddit:
+            return tor_link in reply.body and "^(I'm a" in reply.body
+
+        else:
+            return tor_link in reply.body and '&#32;' in reply.body
     else:
         # If we don't want the check to take place, we'll just return
         # true to negate it.
@@ -68,9 +75,9 @@ def _thread_author_check(original_post, history_item, cfg):
 
 def _author_history_check(post, cfg):
     """
-    Pull the five latest items from the user's history. Chances are that's
+    Pull the ten latest comments from the user's history. Chances are that's
     enough to see if they've actually done the post or not without slowing
-    everything down _too_ much. See if any of those five items look right
+    everything down _too_ much. See if any of those ten items look right
     and complete the post if it's the transcript we're looking for.
 
     Warning: this is not very fast, but it does the job. Definitely something

--- a/tor/strings/en_US.yml
+++ b/tor/strings/en_US.yml
@@ -104,6 +104,9 @@ responses:
       Don't forget to follow the formatting that I link above, and don't be shy to ask for assistance in either our [Discord](https://discord.gg/b5DqZXq) or [message the mods!](https://www.reddit.com/message/compose?to=%2Fr%2FTranscribersOfReddit&subject=Transcription%20Help&message=)
 
       Cheers!
+    new_reddit_transcript: |
+
+      P.S. It looks like you're using the Fancy Pants Editor on New Reddit -- this will cause many of our templates to not work correctly. See [here](https://reddit.com/r/transcribersofreddit/wiki/new_reddit) for more details.
   direct_message:
     subject: |
       Username Call


### PR DESCRIPTION
Right now we can detect transcriptions when they've been put in the r/ToR thread, but not if they're done using the new reddit formatter. This PR extends the current functionality to include the WYSIWYG editor mangling our footer.

Signed-off-by: Joe Kaufeld <joe.kaufeld@gmail.com>