### PR TITLE
Fixes crash if post has report with body 'null'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [UNRELEASED]
+
+- Skip mod flags that (somehow) come back as `null`, because obviously human intervention is needed (credit @thelonelyghost)
+
 ## [3.12.0] - 2019-12-12
 
 - Replaces `setup.py` with Poetry tooling for development and packaging ease

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [UNRELEASED]
 
 - Skip mod flags that (somehow) come back as `null`, because obviously human intervention is needed (credit @thelonelyghost)
+- Add link to tutorial for first transcriptions (credit @Pf441)
 
 ## [3.12.0] - 2019-12-12
 

--- a/tor/core/inbox.py
+++ b/tor/core/inbox.py
@@ -118,7 +118,6 @@ def process_reply(reply, cfg):
         # the only way we should hit this is if somebody comments and then
         # deletes their comment before the bot finished processing. It's
         # uncommon, but common enough that this is necessary.
-        pass
 
 
 def check_inbox(cfg):

--- a/tor/core/user_interaction.py
+++ b/tor/core/user_interaction.py
@@ -270,6 +270,8 @@ def process_unclaim(post, cfg):
         return
 
     for item in top_parent.user_reports:
+        if not item[0]:
+            continue
         if (
             reports.original_post_deleted_or_locked in item[0] or reports.post_violates_rules in item[0]
         ):


### PR DESCRIPTION
Apparently there's a way to flag a post for moderation while having the report itself be null, which makes the bot bomb out. Better to err on the side of caution and just have the bot skip over the report in favor of a human looking at it than try to handle it automatically.
