### PR TITLE
Swaps out Travis CI badge for GitHub Actions status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![GitHub Actions CI status](https://github.com/GrafeasGroup/tor/workflows/automated-tests/badge.svg)
+![GitHub Actions CI status](https://github.com/GrafeasGroup/tor/workflows/Automated%20Testing/badge.svg)
 
 # Transcribers of Reddit
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Travis build status](https://img.shields.io/travis/GrafeasGroup/tor.svg)](https://travis-ci.org/GrafeasGroup/tor)
+![GitHub Actions CI status](https://github.com/GrafeasGroup/tor/workflows/automated-tests/badge.svg)
 
 # Transcribers of Reddit
 


### PR DESCRIPTION
See official docs: https://help.github.com/en/actions/configuring-and-managing-workflows/configuring-a-workflow#adding-a-workflow-status-badge-to-your-repository

Purely administrative, so I'm skipping the changelog entry