### PR TITLE
Add Blossom integration for the "Claim" message processing

### DIFF
--- a/tor/core/blossom_wrapper.py
+++ b/tor/core/blossom_wrapper.py
@@ -150,8 +150,7 @@ class BlossomAPI:
     def claim_submission(self, submission_id: str, username: str) -> BlossomResponse:
         """Claim the specified submission with the specified username."""
         response = self.patch(
-            f"/submission/{submission_id}/claim/",
-            data={"username": username}
+            f"/submission/{submission_id}/claim/", data={"username": username}
         )
         if response.status_code == 201:
             return BlossomResponse(data=response.json())

--- a/tor/core/blossom_wrapper.py
+++ b/tor/core/blossom_wrapper.py
@@ -1,15 +1,22 @@
-from enum import Enum, auto
-from typing import Dict
+from dataclasses import dataclass
+from enum import auto, Enum
+from typing import Any, Dict
 
 from requests import Request, Response, Session
 
 
-class BlossomResponse(Enum):
+class BlossomStatus(Enum):
     ok = auto()
     not_found = auto()
     missing_prerequisite = auto()
     other_user = auto()
     already_completed = auto()
+
+
+@dataclass
+class BlossomResponse:
+    data: Dict[str, Any] = None
+    status: BlossomStatus = BlossomStatus.ok
 
 
 class BlossomAPI:
@@ -119,3 +126,39 @@ class BlossomAPI:
     def patch(self, path: str, data=None, params=None) -> Response:
         """Request a PATCH request to the API."""
         return self._call("PATCH", path, data, params)
+
+    def create_user(self, username: str) -> BlossomResponse:
+        """Create a new user with the given username."""
+        response = self.get("/volunteer/", data={"username": username})
+        if response.status_code == 201:
+            return BlossomResponse(status=BlossomStatus.ok, data=response.json())
+        elif response.status_code == 422:
+            return BlossomResponse(status=BlossomStatus.already_completed)
+        response.raise_for_status()
+        return BlossomResponse()
+
+    def get_submission(self, reddit_id: str) -> BlossomResponse:
+        """Get the Blossom Submission corresponding to the provided Reddit ID."""
+        response = self.get("/submission/", params={"original_id": reddit_id})
+        response.raise_for_status()
+        results = response.json()['results']
+        if results:
+            return BlossomResponse(data=results[0])
+        else:
+            return BlossomResponse(status=BlossomStatus.not_found)
+
+    def claim_submission(self, submission_id: str, username: str) -> BlossomResponse:
+        """Claim the specified submission with the specified username."""
+        response = self.patch(
+            f"/submission/{submission_id}/claim/",
+            data={"username": username}
+        )
+        if response.status_code == 201:
+            return BlossomResponse(data=response.json())
+        elif response.status_code == 404:
+            return BlossomResponse(status=BlossomStatus.not_found)
+        elif response.status_code == 409:
+            return BlossomResponse(status=BlossomStatus.other_user)
+        # TODO: Add the response for when CoC has not yet been accepted.
+        response.raise_for_status()
+        return BlossomResponse()

--- a/tor/core/user_interaction.py
+++ b/tor/core/user_interaction.py
@@ -82,12 +82,12 @@ def process_claim(post: Comment, cfg: Config, first_time=False) -> None:
     This function sends a reply depending on the response from Blossom and
     creates an user when this is the first time a user uses the bot.
     """
-    top_parent = get_parent_post_id(post, cfg.r)
-    if top_parent.author.name not in __BOT_NAMES__:
+    submission = post.submission
+    if submission.author.name not in __BOT_NAMES__:
         log.debug("Received 'claim' on post we do not own. Ignoring.")
         return
 
-    response = cfg.blossom.get_submission(reddit_id=top_parent.fullname)
+    response = cfg.blossom.get_submission(reddit_id=submission.fullname)
     if response.status != BlossomStatus.ok:
         # If we are here, this means that the current submission is not yet in Blossom.
         # TODO: Create the Submission in Blossom and try this method again.
@@ -98,8 +98,8 @@ def process_claim(post: Comment, cfg: Config, first_time=False) -> None:
     )
     if response.status == BlossomStatus.ok:
         message = i18n["responses"]["claim"]["first_claim_success" if first_time else "success"]
-        flair_post(top_parent, flair.in_progress)
-        log.info(f'Claim on ID {top_parent.fullname} by {post.author} successful.')
+        flair_post(submission, flair.in_progress)
+        log.info(f'Claim on Submission {submission.fullname} by {post.author} successful.')
     elif response.status == BlossomStatus.missing_prerequisite:
         message = i18n["responses"]["general"]["coc_not_accepted"].format(get_wiki_page("codeofconduct", cfg))
     elif response.status == BlossomStatus.not_found:

--- a/tor/strings/en_US.yml
+++ b/tor/strings/en_US.yml
@@ -66,8 +66,6 @@ responses:
       Please respond with `done` when complete so we can check this one off the list!
     already_claimed: |
       I'm sorry, but it looks like someone else has already claimed this post! You can check in with them to see if they need any help, but otherwise I suggest sticking around to see if another post pops up here in a little bit.
-    already_complete: |
-      This post has already been completed! Perhaps you can find a new one on the front page?
   done:
     still_unclaimed: |
       This post is still unclaimed! Please claim it first or message the mods to take care of this.


### PR DESCRIPTION
Add integration for the "claim" message processing. Note that this removes the need for the `already_completed` message, as this falls under the error message of `already_claimed`. Please also note #187 on this topic.