### PR TITLE
remove older (incompatible) versions of python

### DIFF
--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -32,8 +32,6 @@ jobs:
       max-parallel: 4
       matrix:
         python-version:
-          - '3.6'
-          - '3.7'
           - '3.8'
 
     steps:


### PR DESCRIPTION
The use of new features means that the automated tests can't use older versions of python anymore -- this limits the only usable version to 3.8 (and we can expand outwards once 3.9 is released -- I would have added the nightly build, but github actions only supports full releases of python).

Signed-off-by: Joe Kaufeld <joe.kaufeld@gmail.com>