### PR TITLE
Update Video Format Page

### DIFF
--- a/tor/core/initialize.py
+++ b/tor/core/initialize.py
@@ -36,7 +36,7 @@ def populate_formatting(cfg: Config) -> None:
     :return: None.
     """
     cfg.audio_formatting = get_wiki_page('format/audio', cfg)
-    cfg.video_formatting = get_wiki_page('format/video', cfg)
+    cfg.video_formatting = get_wiki_page('formats/video', cfg)
     cfg.image_formatting = get_wiki_page('format/images', cfg)
     cfg.other_formatting = get_wiki_page('format/other', cfg)
 


### PR DESCRIPTION
So we have three video format pages:

* /examples/video
* /format/video
* /formats/video

Of all of them, the one that's actually updated and linked to on the sub sidebar is /format**s**/video/, so this change simply redirects the loaded wiki page to the one that's actually used. After this is deployed, we should decommission the other pages.