### PR TITLE
Patch breaking bug for private subreddits

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tor"
-version = "4.2.2"
+version = "4.2.3"
 description = "A bot that handles moderating and scoring in /r/TranscribersOfReddit"
 authors = ["Grafeas Group <devs@grafeas.org>"]
 license = "MIT"

--- a/tor/__init__.py
+++ b/tor/__init__.py
@@ -1,6 +1,6 @@
 import os
 
-__version__ = '4.2.2'
+__version__ = '4.2.3'
 __SELF_NAME__ = 'transcribersofreddit'
 __BOT_NAMES__ = os.environ.get('BOT_NAMES', 'transcribersofreddit,tor_archivist,transcribot').split(',')
 __root__ = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))

--- a/tor/core/validation.py
+++ b/tor/core/validation.py
@@ -117,7 +117,7 @@ def verified_posted_transcript(post: Comment, cfg: Config) -> bool:
     :param cfg: the global config object.
     :return: True if a post is found, False if not.
     """
-    forbidden = False
+    forbidden: bool = False
     top_parent: Submission = get_parent_post_id(post, cfg.r)
     linked_resource: Submission = cfg.r.submission(top_parent.id_from_url(top_parent.url))
 

--- a/tor/core/validation.py
+++ b/tor/core/validation.py
@@ -1,4 +1,5 @@
 from praw.models import Comment, Submission  # type: ignore
+from prawcore.exceptions import Forbidden
 
 from tor.core.config import Config
 from tor.core.helpers import get_parent_post_id, send_to_modchat
@@ -116,25 +117,36 @@ def verified_posted_transcript(post: Comment, cfg: Config) -> bool:
     :param cfg: the global config object.
     :return: True if a post is found, False if not.
     """
+    forbidden = False
     top_parent: Submission = get_parent_post_id(post, cfg.r)
     linked_resource: Submission = cfg.r.submission(top_parent.id_from_url(top_parent.url))
 
+    try:
     # get rid of the "See More Comments" crap
-    linked_resource.comments.replace_more(limit=0)
-    for top_level_comment in linked_resource.comments.list():
-        if not _author_check(post, top_level_comment):
-            continue
-        if not _footer_check(top_level_comment, cfg):
-            continue
-        return True
+        linked_resource.comments.replace_more(limit=0)
+        for top_level_comment in linked_resource.comments.list():
+            if not _author_check(post, top_level_comment):
+                continue
+            if not _footer_check(top_level_comment, cfg):
+                continue
+            return True
+    except Forbidden:
+        # we've attempted to load a subreddit that we don't have access to. The
+        # only way this can happen (reasonably) is when the sub goes private
+        # after we've already pulled the submission from it. In this case, we
+        # will default to the author history check.
+        forbidden = True
 
     # Did their transcript get flagged by the spam filter? Check their history.
     if _author_history_check(post, cfg):
-        send_to_modchat(
-            f'Found removed post: <{post.submission.shortlink}>',
-            cfg,
-            channel='#removed_posts'
-        )
+        # We only want to complain about it being removed if it was
+        # actually removed.
+        if not forbidden:
+            send_to_modchat(
+                f'Found removed post: <{post.submission.shortlink}>',
+                cfg,
+                channel='#removed_posts'
+            )
         return True
 
     return False


### PR DESCRIPTION
Wraps the call to load the target submission with a check to get a 403 forbidden, which is what Reddit returns through the API if you try and access a specific ID behind a private subreddit. This new behavior will fall through to the author check and, if successful, will not trigger the slack ping about a removed post.