### PR TITLE
Add warning about "I agree"

### DIFF
--- a/tor/strings/en_US.yml
+++ b/tor/strings/en_US.yml
@@ -101,7 +101,9 @@ responses:
       Something appears to have gone wrong. Please message the moderators of r/TranscribersOfReddit to have them look at this. Thanks!
     coc_not_accepted: |
       Hi there! Please read and accept our Code of Conduct so that we can get you started with transcribing. Please read the Code of Conduct below, then respond to this comment with `I accept`.
-
+      
+      **NOTE**: please write `I accept` as-is: variations like `I agree` or `Accept` won't work. Editing the old comment to be `I accept` won't work either.
+      
       After you respond, I'll process your claim as normal. A mod will check in and give you feedback when you’re finished!
 
       ---


### PR DESCRIPTION
We have had a lot of new volunteers writing "I agree" or "accept" instead of "I accept", which is a problem since their claim won't be processed. I added an explicit warning about that in the message of the bot introducing the Code of Conduct.