### PR TITLE
Add debug command

### DIFF
--- a/tor/cli/main.py
+++ b/tor/cli/main.py
@@ -36,6 +36,8 @@ DEBUG_MODE = bool(os.getenv('DEBUG_MODE', ''))
 # Jake L (2017-11-17)
 # Michael W (2017-11-27)
 # Luke Abby (2019-07-02)
+# David G (2021-06-14)
+# Jason H (2021-07-01)
 
 # Musical Dedications:
 #

--- a/tor/core/__init__.py
+++ b/tor/core/__init__.py
@@ -1,3 +1,5 @@
+import re
+
 __version__ = '0.6.0'
 
 # CTRL+C handler variable
@@ -46,3 +48,14 @@ class cached_property(object):
             value = self.func(obj)
             obj.__dict__[self.__name__] = value
         return value
+
+
+MOD_SUPPORT_PHRASES = [
+    re.compile('fuck', re.IGNORECASE),
+    re.compile('undo', re.IGNORECASE),
+    # re.compile('(?:good|bad) bot', re.IGNORECASE),
+]
+
+CLAIM_PHRASES = ["claim", "dibs"]
+DONE_PHRASES = ['done', 'deno', 'doen']
+UNCLAIM_PHRASES = ['unclaim', 'cancel']

--- a/tor/core/admin_commands.py
+++ b/tor/core/admin_commands.py
@@ -6,6 +6,7 @@ from typing import Dict
 import beeline
 from praw.models import Redditor
 
+from tor.core import CLAIM_PHRASES, DONE_PHRASES
 from tor.core.helpers import _, clean_id, send_to_modchat
 from tor.core.initialize import initialize
 from tor.core.user_interaction import process_done
@@ -126,7 +127,7 @@ def process_override(user: Redditor, blossom_submission: Dict, parent_id: str, c
     # parent. That should be the comment with the `done` call in it.
     reply_parent = cfg.r.comment(id=clean_id(parent_id))
     grandparent = cfg.r.comment(id=clean_id(reply_parent.parent_id))
-    if 'done' in grandparent.body.lower() or 'claim' in grandparent.body.lower():
+    if grandparent.body.lower() in (CLAIM_PHRASES + DONE_PHRASES):
         logging.info(
             f'Starting validation override for post {grandparent.fullname}, '
             f'approved by {user.name}'
@@ -147,10 +148,10 @@ def reload_config(reply, cfg):
     return 'Config reloaded!'
 
 
-def ping(reply, cfg):
+def ping(reply, cfg) -> str:
     """
     Replies to the !ping command, and is used as a keep alive check
-    :param reply: Not used, but it is here due to the way the function is called
+    :param reply: Message object
     :param cfg: See reply param
     :return: The ping string, which in turn is given to Reddit's reply.reply()
     """
@@ -158,3 +159,8 @@ def ping(reply, cfg):
         f'Received ping from {reply.author.name}. Pong!'
     )
     return "Pong!"
+
+
+@beeline.traced(name='process_debug')
+def process_debug(message):
+    ...

--- a/tor/core/inbox.py
+++ b/tor/core/inbox.py
@@ -26,6 +26,10 @@ MOD_SUPPORT_PHRASES = [
     # re.compile('(?:good|bad) bot', re.IGNORECASE),
 ]
 
+CLAIM_PHRASES = ["claim", "dibs"]
+DONE_PHRASES = ['done', 'deno', 'doen']
+UNCLAIM_PHRASES = ['unclaim', 'cancel']
+
 log = logging.getLogger(__name__)
 
 
@@ -79,15 +83,17 @@ def process_reply(reply: Comment, cfg: Config) -> None:
                 message, flair = process_coc(
                     username, reply.context, blossom_submission, cfg
                 )
-            elif 'unclaim' in r_body or 'cancel' in r_body:
+            elif r_body in UNCLAIM_PHRASES:
                 message, flair = process_unclaim(
                     username, blossom_submission, submission, cfg
                 )
-            elif 'claim' in r_body or 'dibs' in r_body:
+            elif r_body in CLAIM_PHRASES:
                 message, flair = process_claim(username, blossom_submission, cfg)
-            elif 'done' in r_body or 'deno' in r_body or 'doen' in r_body:
+            elif r_body in DONE_PHRASES:
                 alt_text = 'done' not in r_body
-                message, flair = process_done(reply.author, blossom_submission, reply, cfg, alt_text_trigger=alt_text)
+                message, flair = process_done(
+                    reply.author, blossom_submission, reply, cfg, alt_text_trigger=alt_text
+                )
             elif '!override' in r_body:
                 message, flair = process_override(reply.author, blossom_submission, reply.parent_id, cfg)
             else:
@@ -99,14 +105,14 @@ def process_reply(reply: Comment, cfg: Config) -> None:
             flair_post(reply.submission, flair)
 
     except (ClientException, AttributeError) as e:
+        # the only way we should hit this is if somebody comments and then
+        # deletes their comment before the bot finished processing. It's
+        # uncommon, but common enough that this is necessary.
         log.warning(e)
         log.warning(
             f"Unable to process comment {reply.submission.shortlink} "
             f"by {reply.author}"
         )
-        # the only way we should hit this is if somebody comments and then
-        # deletes their comment before the bot finished processing. It's
-        # uncommon, but common enough that this is necessary.
 
 
 @beeline.traced(name='process_mention')

--- a/tor/core/inbox.py
+++ b/tor/core/inbox.py
@@ -108,7 +108,7 @@ def process_reply(reply: Comment, cfg: Config) -> None:
                     reply.author, blossom_submission, reply.parent_id, cfg
                 )
             elif "!debug" in r_body:
-                message, flair = process_debug()
+                message, flair = process_debug(reply.author, blossom_submission, cfg)
             else:
                 # If we made it this far, it's something we can't process automatically
                 forward_to_slack(reply, cfg)

--- a/tor/core/inbox.py
+++ b/tor/core/inbox.py
@@ -1,6 +1,5 @@
 import logging
 import random
-import re
 
 import beeline
 from praw.exceptions import ClientException
@@ -8,27 +7,20 @@ from praw.models import Comment, Message
 from praw.models.reddit.mixins import InboxableMixin
 
 from tor import __BOT_NAMES__
-from tor.core import validation
-from tor.core.admin_commands import process_command, process_override
+from tor.core import (
+    validation, CLAIM_PHRASES, DONE_PHRASES, MOD_SUPPORT_PHRASES, UNCLAIM_PHRASES
+)
+from tor.core.admin_commands import process_command, process_override, process_debug
 from tor.core.config import Config
 from tor.core.helpers import _, is_our_subreddit, send_reddit_reply, send_to_modchat
 from tor.core.posts import get_blossom_submission
+from tor.core.user_interaction import (
+    process_claim, process_coc, process_done, process_message, process_unclaim
+)
 from tor.helpers.flair import flair_post
-from tor.core.user_interaction import (process_claim, process_coc,
-                                       process_done, process_message,
-                                       process_unclaim,)
 from tor.strings import translation
 
 i18n = translation()
-MOD_SUPPORT_PHRASES = [
-    re.compile('fuck', re.IGNORECASE),
-    re.compile('undo', re.IGNORECASE),
-    # re.compile('(?:good|bad) bot', re.IGNORECASE),
-]
-
-CLAIM_PHRASES = ["claim", "dibs"]
-DONE_PHRASES = ['done', 'deno', 'doen']
-UNCLAIM_PHRASES = ['unclaim', 'cancel']
 
 log = logging.getLogger(__name__)
 
@@ -96,6 +88,8 @@ def process_reply(reply: Comment, cfg: Config) -> None:
                 )
             elif '!override' in r_body:
                 message, flair = process_override(reply.author, blossom_submission, reply.parent_id, cfg)
+            elif '!debug' in r_body:
+                message, flair = process_debug()
             else:
                 # If we made it this far, it's something we can't process automatically
                 forward_to_slack(reply, cfg)

--- a/tor/core/inbox.py
+++ b/tor/core/inbox.py
@@ -8,14 +8,22 @@ from praw.models.reddit.mixins import InboxableMixin
 
 from tor import __BOT_NAMES__
 from tor.core import (
-    validation, CLAIM_PHRASES, DONE_PHRASES, MOD_SUPPORT_PHRASES, UNCLAIM_PHRASES
+    validation,
+    CLAIM_PHRASES,
+    DONE_PHRASES,
+    MOD_SUPPORT_PHRASES,
+    UNCLAIM_PHRASES,
 )
 from tor.core.admin_commands import process_command, process_override, process_debug
 from tor.core.config import Config
 from tor.core.helpers import _, is_our_subreddit, send_reddit_reply, send_to_modchat
 from tor.core.posts import get_blossom_submission
 from tor.core.user_interaction import (
-    process_claim, process_coc, process_done, process_message, process_unclaim
+    process_claim,
+    process_coc,
+    process_done,
+    process_message,
+    process_unclaim,
 )
 from tor.helpers.flair import flair_post
 from tor.strings import translation
@@ -25,23 +33,24 @@ i18n = translation()
 log = logging.getLogger(__name__)
 
 
-@beeline.traced(name='forward_to_slack')
+@beeline.traced(name="forward_to_slack")
 def forward_to_slack(item: InboxableMixin, cfg: Config) -> None:
     username = str(item.author.name)
 
     send_to_modchat(
         f'<{i18n["urls"]["reddit_url"].format(item.context)}|Unhandled message>'
-        f' by'
+        f" by"
         f' <{i18n["urls"]["reddit_url"].format("/u/" + username)}|u/{username}> -- '
-        f'*{item.subject}*:\n{item.body}', cfg
+        f"*{item.subject}*:\n{item.body}",
+        cfg,
     )
     log.info(
-        f'Received unhandled inbox message from {username}. \n Subject: '
-        f'{item.subject}\n\nBody: {item.body} '
+        f"Received unhandled inbox message from {username}. \n Subject: "
+        f"{item.subject}\n\nBody: {item.body} "
     )
 
 
-@beeline.traced(name='process_reply')
+@beeline.traced(name="process_reply")
 def process_reply(reply: Comment, cfg: Config) -> None:
     try:
         log.debug(f"Received reply from {reply.author.name}: {reply.body}")
@@ -49,19 +58,23 @@ def process_reply(reply: Comment, cfg: Config) -> None:
         flair = None
         r_body = reply.body.lower()  # cache that thing
 
-        if 'image transcription' in r_body or validation.contains_footer(reply, cfg):
-            message = _(i18n['responses']['general']['transcript_on_tor_post'])
-        elif matches := [match.group() for match in [regex.search(reply.body) for regex in MOD_SUPPORT_PHRASES] if match]:
+        if "image transcription" in r_body or validation.contains_footer(reply, cfg):
+            message = _(i18n["responses"]["general"]["transcript_on_tor_post"])
+        elif matches := [
+            match.group()
+            for match in [regex.search(reply.body) for regex in MOD_SUPPORT_PHRASES]
+            if match
+        ]:
             phrases = '"' + '", "'.join(matches) + '"'
             send_to_modchat(
                 ":rotating_light::rotating_light: Mod Intervention Needed "
                 ":rotating_light::rotating_light: "
-                f'\n\nDetected use of {phrases} {reply.submission.shortlink}',
-                cfg
+                f"\n\nDetected use of {phrases} {reply.submission.shortlink}",
+                cfg,
             )
-        elif 'thank' in r_body:  # trigger on "thanks" and "thank you"
-            thumbs_up_gifs = i18n['urls']['thumbs_up_gifs']
-            youre_welcome = i18n['responses']['general']['youre_welcome']
+        elif "thank" in r_body:  # trigger on "thanks" and "thank you"
+            thumbs_up_gifs = i18n["urls"]["thumbs_up_gifs"]
+            youre_welcome = i18n["responses"]["general"]["youre_welcome"]
             message = _(youre_welcome.format(random.choice(thumbs_up_gifs)))
         else:
             submission = reply.submission
@@ -71,7 +84,7 @@ def process_reply(reply: Comment, cfg: Config) -> None:
                 return
 
             blossom_submission = get_blossom_submission(submission, cfg)
-            if 'i accept' in r_body:
+            if "i accept" in r_body:
                 message, flair = process_coc(
                     username, reply.context, blossom_submission, cfg
                 )
@@ -82,13 +95,19 @@ def process_reply(reply: Comment, cfg: Config) -> None:
             elif r_body in CLAIM_PHRASES:
                 message, flair = process_claim(username, blossom_submission, cfg)
             elif r_body in DONE_PHRASES:
-                alt_text = 'done' not in r_body
+                alt_text = "done" not in r_body
                 message, flair = process_done(
-                    reply.author, blossom_submission, reply, cfg, alt_text_trigger=alt_text
+                    reply.author,
+                    blossom_submission,
+                    reply,
+                    cfg,
+                    alt_text_trigger=alt_text,
                 )
-            elif '!override' in r_body:
-                message, flair = process_override(reply.author, blossom_submission, reply.parent_id, cfg)
-            elif '!debug' in r_body:
+            elif "!override" in r_body:
+                message, flair = process_override(
+                    reply.author, blossom_submission, reply.parent_id, cfg
+                )
+            elif "!debug" in r_body:
                 message, flair = process_debug()
             else:
                 # If we made it this far, it's something we can't process automatically
@@ -109,7 +128,7 @@ def process_reply(reply: Comment, cfg: Config) -> None:
         )
 
 
-@beeline.traced(name='process_mention')
+@beeline.traced(name="process_mention")
 def process_mention(mention: Comment) -> None:
     """
     Handles username mentions and handles the formatting and posting of
@@ -119,12 +138,12 @@ def process_mention(mention: Comment) -> None:
     :return: None.
     """
     try:
-        pm_subject = i18n['responses']['direct_message']['subject']
-        pm_body = i18n['responses']['direct_message']['body']
+        pm_subject = i18n["responses"]["direct_message"]["subject"]
+        pm_body = i18n["responses"]["direct_message"]["body"]
 
         # message format is subject, then body
         mention.author.message(pm_subject, _(pm_body))
-        log.info(f'Message sent to {mention.author.name}!')
+        log.info(f"Message sent to {mention.author.name}!")
     except (ClientException, AttributeError):
         # apparently this crashes with an AttributeError if someone
         # calls the bot and immediately deletes their comment. This
@@ -132,7 +151,7 @@ def process_mention(mention: Comment) -> None:
         pass
 
 
-@beeline.traced(name='check_inbox')
+@beeline.traced(name="check_inbox")
 def check_inbox(cfg: Config) -> None:
     """
     Goes through all the unread messages in the inbox. It deliberately
@@ -151,7 +170,8 @@ def check_inbox(cfg: Config) -> None:
         if author_name is None:
             send_to_modchat(
                 f"We received a message without an author -- "
-                f"*{item.subject}*:\n{item.body}", cfg
+                f"*{item.subject}*:\n{item.body}",
+                cfg,
             )
         elif author_name == "transcribot":
             # bot responses shouldn't trigger workflows in other bots

--- a/tor/core/user_interaction.py
+++ b/tor/core/user_interaction.py
@@ -164,6 +164,7 @@ def process_done(
         # this edge case.
         return coc_not_accepted.format(get_wiki_page("codeofconduct", cfg)), return_flair
 
+    # TODO: fix override command
     transcription, is_visible = get_transcription(blossom_submission["url"], user, cfg)
     if transcription is None:
         message = done_messages["cannot_find_transcript"]

--- a/tor/core/user_interaction.py
+++ b/tor/core/user_interaction.py
@@ -261,9 +261,8 @@ def process_message(message: Message, cfg: Config) -> None:
     author = message.author
     username = author.name if author else None
 
-    author.message(dm_subject, dm_body)
-
     if username:
+        author.message(dm_subject, dm_body)
         send_to_modchat(
             f'DM from <{i18n["urls"]["reddit_url"].format("/u/" + username)}|u/{username}> -- '
             f'*{message.subject}*:\n{message.body}', cfg


### PR DESCRIPTION
This PR is fairly large for the actual number of material changes in it; most of it is `black` and various cleanups that I stumbled over while implementing this command. Full list of changes:

* update donor comment
* move all common string phrases to `tor/core/__init__.py` to allow importing from more than one place
* update `!override` to work on any source comment that is valid for claim or done, like `deno`
* don't attempt to send the "hey I don't respond to DMs" message to an account that doesn't exist (for the messages from reddit as a platform)
* add a `!debug` command that just prints out the Blossom object for the current submission. Should make the next step in debugging immediately obvious when working with a troublesome submission.