### PR TITLE
closes #227: fix override breaking if no transcription is found

### DIFF
--- a/tor/core/helpers.py
+++ b/tor/core/helpers.py
@@ -17,7 +17,6 @@ from tor.core.config import config, Config
 from tor.helpers.reddit_ids import is_removed
 from tor.strings import translation
 
-
 log = logging.getLogger(__name__)
 
 subreddit_regex = re.compile(

--- a/tor/core/user_interaction.py
+++ b/tor/core/user_interaction.py
@@ -180,7 +180,7 @@ def process_done(
 
     if transcription or override:
         # because we can enter this state with or without a transcription, it
-        # makes sense to have this is a separate block.
+        # makes sense to have this as a separate block.
         done_response = cfg.blossom.done(
             blossom_submission["id"], user.name, override
         )

--- a/tor/core/user_interaction.py
+++ b/tor/core/user_interaction.py
@@ -7,8 +7,9 @@ from blossom_wrapper import BlossomStatus
 from praw.models import Comment, Message, Redditor, Submission
 
 from tor.core.config import Config
-from tor.core.helpers import (get_wiki_page,
-                              remove_if_required, send_to_modchat)
+from tor.core.helpers import (
+    get_wiki_page, remove_if_required, send_to_modchat
+)
 from tor.core.validation import get_transcription
 from tor.helpers.flair import flair, set_user_flair
 from tor.strings import translation
@@ -164,11 +165,10 @@ def process_done(
         # this edge case.
         return coc_not_accepted.format(get_wiki_page("codeofconduct", cfg)), return_flair
 
-    # TODO: fix override command
     transcription, is_visible = get_transcription(blossom_submission["url"], user, cfg)
-    if transcription is None:
-        message = done_messages["cannot_find_transcript"]
-    else:
+
+    message = done_messages["cannot_find_transcript"]  # default message
+    if transcription:
         cfg.blossom.create_transcription(
             transcription.id,
             transcription.body,
@@ -178,6 +178,9 @@ def process_done(
             not is_visible
         )
 
+    if transcription or override:
+        # because we can enter this state with or without a transcription, it
+        # makes sense to have this is a separate block.
         done_response = cfg.blossom.done(
             blossom_submission["id"], user.name, override
         )
@@ -202,9 +205,6 @@ def process_done(
 
         elif done_response.status == BlossomStatus.blacklisted:
             message = i18n["responses"]["general"]["blacklisted"]
-
-        else:
-            message = done_messages["cannot_find_transcript"]
 
     return message, return_flair
 


### PR DESCRIPTION
When trying to perform an override, the current process hinges on whether or not a transcription is found. If the transcription is removed (or doesn't exist) then the override will fail. This PR moves the actual "done" logic to a separate check to see if we find the transcription OR an override has been triggered.