### PR TITLE
Fix Unclaim

### DIFF
--- a/tor/core/helpers.py
+++ b/tor/core/helpers.py
@@ -283,7 +283,7 @@ def remove_if_required(
             f"submission/{blossom_id}/",
             data={"removed_from_queue": True},
         )
-        if response.status != BlossomStatus.ok:
+        if not str(response.status_code).startswith('2'):
             return False, False
 
         # Selects a message depending on whether the submission is reported or not.


### PR DESCRIPTION
The reason that unclaim isn't working right now is because the code expects a blossomstatus enum from the PATCH call (which honestly does make sense) but until @MaxVanDeursen's work on refactoring the wrapper is complete, the raw methods just return Requests objects. This PR addresses that issue; the fix was tested in prod and confirmed working.