### PR TITLE
Allow claim, done, and unclaim with extra content

### DIFF
--- a/tor/core/helpers.py
+++ b/tor/core/helpers.py
@@ -266,6 +266,16 @@ def _check_removal_required(submission: Submission, cfg: Config) -> Tuple[bool, 
     return False, False
 
 
+def check_for_phrase(content: str, phraselist: List) -> bool:
+    """
+    See if a substring from the list is in the content.
+
+    This allows us to handle somewhat uncommon (but relied-upon) behavior like
+    'done -- this is an automated action'.
+    """
+    return any([option in content for option in phraselist])
+
+
 @beeline.traced(name='remove_if_required')
 def remove_if_required(
     submission: Submission, blossom_id: str, cfg: Config

--- a/tor/core/inbox.py
+++ b/tor/core/inbox.py
@@ -16,7 +16,9 @@ from tor.core import (
 )
 from tor.core.admin_commands import process_command, process_override, process_debug
 from tor.core.config import Config
-from tor.core.helpers import _, is_our_subreddit, send_reddit_reply, send_to_modchat
+from tor.core.helpers import (
+    _, is_our_subreddit, send_reddit_reply, send_to_modchat, check_for_phrase
+)
 from tor.core.posts import get_blossom_submission
 from tor.core.user_interaction import (
     process_claim,
@@ -88,13 +90,13 @@ def process_reply(reply: Comment, cfg: Config) -> None:
                 message, flair = process_coc(
                     username, reply.context, blossom_submission, cfg
                 )
-            elif r_body in UNCLAIM_PHRASES:
+            elif check_for_phrase(r_body, UNCLAIM_PHRASES):
                 message, flair = process_unclaim(
                     username, blossom_submission, submission, cfg
                 )
-            elif r_body in CLAIM_PHRASES:
+            elif check_for_phrase(r_body, CLAIM_PHRASES):
                 message, flair = process_claim(username, blossom_submission, cfg)
-            elif r_body in DONE_PHRASES:
+            elif check_for_phrase(r_body, DONE_PHRASES):
                 alt_text = "done" not in r_body
                 message, flair = process_done(
                     reply.author,


### PR DESCRIPTION
Something that the third party systems use is strings like "done -- this was an automated action". https://github.com/GrafeasGroup/tor/pull/228 accidentally broke that, so this PR reinstates that ability.