### PR TITLE
Add more valid words for commands

### DIFF
--- a/tor/core/__init__.py
+++ b/tor/core/__init__.py
@@ -56,6 +56,6 @@ MOD_SUPPORT_PHRASES = [
     # re.compile('(?:good|bad) bot', re.IGNORECASE),
 ]
 
-CLAIM_PHRASES = ["claim", "dibs"]
+CLAIM_PHRASES = ["claim", "dibs", "clai", "caim", "clam"]
 DONE_PHRASES = ['done', 'deno', 'doen', 'dome', 'doone']
 UNCLAIM_PHRASES = ['unclaim', 'cancel', 'unclai']

--- a/tor/core/__init__.py
+++ b/tor/core/__init__.py
@@ -57,5 +57,5 @@ MOD_SUPPORT_PHRASES = [
 ]
 
 CLAIM_PHRASES = ["claim", "dibs"]
-DONE_PHRASES = ['done', 'deno', 'doen']
-UNCLAIM_PHRASES = ['unclaim', 'cancel']
+DONE_PHRASES = ['done', 'deno', 'doen', 'dome', 'doone']
+UNCLAIM_PHRASES = ['unclaim', 'cancel', 'unclai']


### PR DESCRIPTION
Since we've been seeing some additional new misspellings come through, seems like a reasonable idea to add them to the bot since it's pretty clear what they're trying to attempt.