### PR TITLE
Fix handling submissions that Blossom doesn't recognize

### DIFF
--- a/tor/core/helpers.py
+++ b/tor/core/helpers.py
@@ -6,7 +6,6 @@ import time
 from typing import List, Tuple
 
 import beeline
-from blossom_wrapper import BlossomStatus
 from praw.exceptions import APIException
 from praw.models import Comment, Submission, Subreddit
 from prawcore.exceptions import RequestException, ServerError, Forbidden, NotFound

--- a/tor/core/posts.py
+++ b/tor/core/posts.py
@@ -170,4 +170,11 @@ def get_blossom_submission(submission: Submission, cfg: Config) -> Dict:
         post_summary["permalink"] = linked_post.permalink
         post_summary["name"] = linked_post.permalink
 
-        return create_blossom_submission(post_summary, submission, cfg)
+        new_submission = create_blossom_submission(post_summary, submission, cfg)
+        # this submission will have the wrong post times because we didn't know about
+        # it, so let's leave a marker that we can clean up later on Blossom's side.
+        cfg.blossom.patch(
+            f"submission/{new_submission['id']}/",
+            data={"redis_id": "incomplete"},
+        )
+        return new_submission

--- a/tor/core/posts.py
+++ b/tor/core/posts.py
@@ -162,4 +162,12 @@ def get_blossom_submission(submission: Submission, cfg: Config) -> Dict:
         return response.data[0]
     else:
         # If we are here, this means that the current submission is not yet in Blossom.
-        return create_blossom_submission(submission, cfg)
+        # Mock up a Blossom object, since this will only be used when Blossom doesn't
+        # know about it
+        post_summary = {}
+        linked_post = cfg.r.submission(url=submission.url)
+        post_summary["url"] = linked_post.url
+        post_summary["permalink"] = linked_post.permalink
+        post_summary["name"] = linked_post.permalink
+
+        return create_blossom_submission(post_summary, submission, cfg)


### PR DESCRIPTION
For posts that were submitted before Blossom, it's entirely reasonable that Blossom won't know about them. Though this shouldn't _really_ happen, there is always the chance that it can and the logic that actually performed this is broken. This PR provides blossom with all the information it needs to create a new submission.