### PR TITLE
Retry finding the transcription once if it cannot be found

### DIFF
--- a/tor/core/user_interaction.py
+++ b/tor/core/user_interaction.py
@@ -1,5 +1,6 @@
 import logging
 import random
+import time
 from typing import Dict, Tuple
 
 import beeline
@@ -171,6 +172,13 @@ def process_done(
     transcription, is_visible = get_transcription(blossom_submission["url"], user, cfg)
 
     message = done_messages["cannot_find_transcript"]  # default message
+
+    if not transcription:
+        # When the user replies `done` quickly after posting the transcription,
+        # it might not be available on Reddit yet. Wait a bit and try again.
+        time.sleep(1)
+        transcription, is_visible = get_transcription(blossom_submission["url"], user, cfg)
+
     if transcription:
         cfg.blossom.create_transcription(
             transcription.id,


### PR DESCRIPTION
Closes #241.

## Description

Sometimes, a transcription is not visible to the Reddit API a short time after posting it. This can lead to the bot not finding the transcription when the user replies `done` quickly. Volunteers has reported this problem to occur a lot more frequently after deploying Blossom.

With this PR, the bot will try to find the transcription again after a short delay if it's not visible already.