### PR TITLE
Handle double claiming and mass claims

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -61,7 +61,7 @@ d = ["aiohttp (>=3.3.2)", "aiohttp-cors"]
 
 [[package]]
 name = "blossom-wrapper"
-version = "0.3.0"
+version = "0.4.0"
 description = ""
 category = "main"
 optional = false
@@ -76,7 +76,7 @@ urllib3 = "^1.26"
 type = "git"
 url = "https://github.com/GrafeasGroup/blossom-wrapper.git"
 reference = "master"
-resolved_reference = "bbce313bbc4271a799e32e7957f5dcd74e27a8ea"
+resolved_reference = "e8ed76bb2b7cca66f81867a3acced969c6f4be3a"
 
 [[package]]
 name = "bugsnag"
@@ -578,7 +578,7 @@ ci = []
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "f13b0ff4211321e9375689b7c07be760d33c9ea4b7d43e13980e657a1c8dc2dc"
+content-hash = "9f643030de10574e3aaccf8cfa29067896308768ef83a5388f31c8bd3c32a2bc"
 
 [metadata.files]
 appdirs = [

--- a/poetry.lock
+++ b/poetry.lock
@@ -281,7 +281,7 @@ test = ["betamax (>=0.8,<0.9)", "betamax-matchers (>=0.3.0,<0.5)", "pytest (>=2.
 
 [[package]]
 name = "prawcore"
-version = "2.2.0"
+version = "2.3.0"
 description = "Low-level communication layer for PRAW 4+."
 category = "main"
 optional = false
@@ -578,7 +578,7 @@ ci = []
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "9f643030de10574e3aaccf8cfa29067896308768ef83a5388f31c8bd3c32a2bc"
+content-hash = "f13b0ff4211321e9375689b7c07be760d33c9ea4b7d43e13980e657a1c8dc2dc"
 
 [metadata.files]
 appdirs = [
@@ -746,8 +746,8 @@ praw = [
     {file = "praw-7.3.0.tar.gz", hash = "sha256:9773fb5a2f5ab910d6f8e14da84e81d8d3d868261745371341d8b2043588ba7c"},
 ]
 prawcore = [
-    {file = "prawcore-2.2.0-py3-none-any.whl", hash = "sha256:cb7a01e43202233d62c4f9c0da890f6e6a534cebc16fb6ef1e71aff7077b0f42"},
-    {file = "prawcore-2.2.0.tar.gz", hash = "sha256:bde42fad459c4dcfe0f22a18921ef4981ee7cd286ea1de3eb697ba91838c9123"},
+    {file = "prawcore-2.3.0-py3-none-any.whl", hash = "sha256:48c17db447fa06a13ca3e722201f443031437708daa736c05a1df895fbcceff5"},
+    {file = "prawcore-2.3.0.tar.gz", hash = "sha256:daf1ccd4b7a80dc4e6567d48336d782e94a9a6dad83770fc2edf76dc9a84f56d"},
 ]
 py = [
     {file = "py-1.10.0-py2.py3-none-any.whl", hash = "sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ bugsnag = "^3.6"
 requests = "^2.22"
 slackclient = "^1"
 PyYaml = "^5.1"
-blossom-wrapper = { git = "https://github.com/GrafeasGroup/blossom-wrapper.git", branch = "master", rev = "e8ed76b" }
+blossom-wrapper = { git = "https://github.com/GrafeasGroup/blossom-wrapper.git", branch = "master" }
 python-dotenv = "^0.14.0"
 praw = "^7.1.0"
 toml = "^0.10.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ bugsnag = "^3.6"
 requests = "^2.22"
 slackclient = "^1"
 PyYaml = "^5.1"
-blossom-wrapper = { git = "https://github.com/GrafeasGroup/blossom-wrapper.git", branch = "master" }
+blossom-wrapper = { git = "https://github.com/GrafeasGroup/blossom-wrapper.git", branch = "master", rev = "e8ed76b" }
 python-dotenv = "^0.14.0"
 praw = "^7.1.0"
 toml = "^0.10.2"

--- a/tor/core/user_interaction.py
+++ b/tor/core/user_interaction.py
@@ -132,6 +132,12 @@ def process_claim(
                 claimed_by=claimed_by
             )
 
+    elif response.status == BlossomStatus.too_many_claims:
+        claimed_links = [submission["tor_url"] for submission in response.data]
+        message = i18n["responses"]["claim"]["too_many_claims"].format(
+            links="\n".join(f"- {link}" for link in claimed_links),
+        )
+
     else:
         message = i18n["responses"]["general"]["oops"]
 

--- a/tor/strings/en_US.yml
+++ b/tor/strings/en_US.yml
@@ -80,6 +80,14 @@ responses:
       I'm sorry, but it looks like u\/{claimed_by} has already claimed this post!
 
       You can check in with them to see if they need any help, but otherwise I suggest sticking around to see if another post pops up here in a little bit.
+    too_many_claims: |
+      Woah, slow down there! Please complete your other claimed posts first before starting a new one:
+
+      {links}
+
+      If you already completed them, reply `done` to me there. If you don't want them anymore, you can use `unclaim`.
+
+      If you need help, reply `help` and I will get a human to assist you!
   done:
     not_claimed_by_user: |
       It does not appear that you have claimed this post! This can be either because this post is not claimed at all or by someone else! If you are unable to resolve this situation, please message the mods.

--- a/tor/strings/en_US.yml
+++ b/tor/strings/en_US.yml
@@ -72,8 +72,14 @@ responses:
       Does this post break the rules? Please report it! If you don't want this post anymore (or can't complete it), respond to this comment with `unclaim`.
 
       Please respond with `done` when complete so we can check this one off the list!
-    already_claimed: |
-      I'm sorry, but it looks like someone else has already claimed this post! You can check in with them to see if they need any help, but otherwise I suggest sticking around to see if another post pops up here in a little bit.
+    already_claimed_by_self: |
+      You already claimed this post!
+
+      If you completed and posted your transcription on the partner sub, reply `done` to me so we can check this one off the list!
+    already_claimed_by_someone: |
+      I'm sorry, but it looks like u\/{claimed_by} has already claimed this post!
+
+      You can check in with them to see if they need any help, but otherwise I suggest sticking around to see if another post pops up here in a little bit.
   done:
     not_claimed_by_user: |
       It does not appear that you have claimed this post! This can be either because this post is not claimed at all or by someone else! If you are unable to resolve this situation, please message the mods.


### PR DESCRIPTION
Relevant issues: Closes #220, closes #187.

This properly handles the user trying to claim a post twice. Instead of saming that "someone" already claimed the post, it will tell the user that they already got the post. If another person claimed it, the bot will tell you who it was (without pinging them).

Additionally, this adds handling for the mass-claim prevention. When a user claimed to many posts, the bot will give them a list of submissions that they still need to complete.

⚠️  This change should be deployed immidiately **before** deploying GrafeasGroup/blossom#183 and GrafeasGroup/blossom#185. ⚠️ 
These PRs contain the API changes necessary for these responses.