### PR TITLE
Add checks for unescaped sub- and usernames

### DIFF
--- a/test/validation/test_formatting_validation.py
+++ b/test/validation/test_formatting_validation.py
@@ -17,7 +17,9 @@ from tor.validation.formatting_validation import (
     PROPER_SEPARATORS_PATTERN,
     HEADING_WITH_DASHES_PATTERN,
     UNESCAPED_USERNAME_PATTERN,
-    check_for_unescaped_username, check_for_unescaped_subreddit, UNESCAPED_SUBREDDIT_PATTERN,
+    check_for_unescaped_username,
+    check_for_unescaped_subreddit,
+    UNESCAPED_SUBREDDIT_PATTERN,
 )
 from tor.validation.formatting_issues import FormattingIssue
 

--- a/test/validation/test_formatting_validation.py
+++ b/test/validation/test_formatting_validation.py
@@ -15,7 +15,7 @@ from tor.validation.formatting_validation import (
     check_for_malformed_footer,
     check_for_bold_header,
     PROPER_SEPARATORS_PATTERN,
-    HEADING_WITH_DASHES_PATTERN,
+    HEADING_WITH_DASHES_PATTERN, UNESCAPED_USERNAME_PATTERN,
 )
 from tor.validation.formatting_issues import FormattingIssue
 
@@ -64,6 +64,28 @@ def test_proper_separator_pattern(test_input: str, should_match: bool) -> None:
 def test_heading_with_dashes_pattern(test_input: str, should_match: bool) -> None:
     """Test if headings made with dashes are recognized correctly."""
     actual = HEADING_WITH_DASHES_PATTERN.search(test_input) is not None
+    assert actual == should_match
+
+
+@pytest.mark.parametrize(
+    "test_input,should_match",
+    [
+        ("u/username", True),  # Username with one slash
+        ("/u/username", True),  # Username with two slashes
+        ("u/123456", True),  # Username with numbers
+        ("u/_username_", True),  # Username with underscores
+        ("u/-username-", True),  # Username with dashes
+        (r"u\/username", False),  # Escaped username with one slash
+        (r"\/u/username", False),  # Escaped username with first slash escaped
+        (r"/u\/username", False),  # Escaped username with second slash escaped
+        (r"\/u\/username", False),  # Escaped username with both slashes escaped
+        (r"r/subreddit", False),  # Subreddit name with one slash
+        (r"/r/subreddit", False),  # Subreddit name with two slashes
+    ],
+)
+def test_unescaped_username_pattern(test_input: str, should_match: bool) -> None:
+    """Test if headings made with dashes are recognized correctly."""
+    actual = UNESCAPED_USERNAME_PATTERN.search(test_input) is not None
     assert actual == should_match
 
 

--- a/test/validation/transcriptions/invalid/unescaped_username_subreddit.txt
+++ b/test/validation/transcriptions/invalid/unescaped_username_subreddit.txt
@@ -1,0 +1,13 @@
+*Image Transcription: Reddit*
+
+---
+
+**Post title**, submitted by **/u/Redditor** to **/r/Subreddit**
+
+[*Description of any unusual text font, background images or color, etc.*]
+
+Post text/content, if any.
+
+---
+
+^^I'm&#32;a&#32;human&#32;volunteer&#32;content&#32;transcriber&#32;for&#32;Reddit&#32;and&#32;you&#32;could&#32;be&#32;too!&#32;[If&#32;you'd&#32;like&#32;more&#32;information&#32;on&#32;what&#32;we&#32;do&#32;and&#32;why&#32;we&#32;do&#32;it,&#32;click&#32;here!](https://www.reddit.com/r/TranscribersOfReddit/wiki/index)

--- a/test/validation/transcriptions/valid/reddit_comment_template.txt
+++ b/test/validation/transcriptions/valid/reddit_comment_template.txt
@@ -1,0 +1,25 @@
+*Image Transcription: Reddit Comments*
+
+---
+
+> **\/u/Commenting Redditor**
+>
+> Comment text.
+
+>> **\/u/ReplyingRedditor**
+>>
+>> Comment text
+
+>>> **\/u/ReplyingRedditor**
+>>>
+>>> Comment Text
+
+>> **\/u/ReplyingRedditor to commenter above this one**
+>>
+>> Comment text
+
+etc.
+
+---
+
+^^I'm&#32;a&#32;human&#32;volunteer&#32;content&#32;transcriber&#32;for&#32;Reddit&#32;and&#32;you&#32;could&#32;be&#32;too!&#32;[If&#32;you'd&#32;like&#32;more&#32;information&#32;on&#32;what&#32;we&#32;do&#32;and&#32;why&#32;we&#32;do&#32;it,&#32;click&#32;here!](https://www.reddit.com/r/TranscribersOfReddit/wiki/index)

--- a/test/validation/transcriptions/valid/reddit_post_template.txt
+++ b/test/validation/transcriptions/valid/reddit_post_template.txt
@@ -1,0 +1,13 @@
+*Image Transcription: Reddit*
+
+---
+
+**Post title**, submitted by **\/u/Redditor** to **\/r/Subreddit**
+
+[*Description of any unusual text font, background images or color, etc.*]
+
+Post text/content, if any.
+
+---
+
+^^I'm&#32;a&#32;human&#32;volunteer&#32;content&#32;transcriber&#32;for&#32;Reddit&#32;and&#32;you&#32;could&#32;be&#32;too!&#32;[If&#32;you'd&#32;like&#32;more&#32;information&#32;on&#32;what&#32;we&#32;do&#32;and&#32;why&#32;we&#32;do&#32;it,&#32;click&#32;here!](https://www.reddit.com/r/TranscribersOfReddit/wiki/index)

--- a/tor/strings/en_US.yml
+++ b/tor/strings/en_US.yml
@@ -259,6 +259,14 @@ formatting_issues:
 
     \    int x = 0;\n
     \   int y = x * 100;"
+  unescaped_username: "**Unescaped username**: You seem to have forgotten to escape a username, i.e. you used `u/username` or `/u/username`.
+    Unfortunately, this gives the user a notification and might annoy them.
+
+    Therefore, please escape the username with a backslash (`\\`), for example `u\\/username` or `\\/u/username`."
+  unescaped_subreddit: "**Unescaped subreddit name**: You seem to have forgotten to escape a subreddit name, i.e. you used `r/subreddit` or `/r/subreddit`.
+    Unfortunately, this might give the sub's mod a notification and could annoy them.
+
+    Therefore, please escape the subreddit name with a backslash (`\\`), for example `r\\/subreddit` or `\\/r/subreddit`."
 urls:
   yt_transcript_url: 'http://video.google.com/timedtext?lang=en&v={}'
   ToR_link: 'www.reddit.com/r/TranscribersOfReddit'

--- a/tor/validation/formatting_issues.py
+++ b/tor/validation/formatting_issues.py
@@ -7,3 +7,4 @@ class FormattingIssue(Enum):
     HEADING_WITH_DASHES = "heading_with_dashes"
     MALFORMED_FOOTER = "malformed_footer"
     FENCED_CODE_BLOCK = "fenced_code_block"
+    UNESCAPED_USERNAME = "unescaped_username"

--- a/tor/validation/formatting_issues.py
+++ b/tor/validation/formatting_issues.py
@@ -8,3 +8,4 @@ class FormattingIssue(Enum):
     MALFORMED_FOOTER = "malformed_footer"
     FENCED_CODE_BLOCK = "fenced_code_block"
     UNESCAPED_USERNAME = "unescaped_username"
+    UNESCAPED_SUBREDDIT = "unescaped_subreddit"

--- a/tor/validation/formatting_validation.py
+++ b/tor/validation/formatting_validation.py
@@ -43,10 +43,16 @@ HEADING_WITH_DASHES_PATTERN = re.compile(r"[\w][:*_ ]*\n[ ]{,3}([-][ ]*){3,}\n")
 FENCED_CODE_BLOCK_PATTERN = re.compile(r"```.*```", re.DOTALL)
 
 # Regex to recognized unescaped usernames.
-# They need to be escaped with a backslash, otherwise the user will be pinged
+# They need to be escaped with a backslash, otherwise the user will be pinged.
 # For example, u/username and /u/username are not allowed.
 # Instead, u\/username, \/u/username or \/u\/username should be used.
-UNESCAPED_USERNAME_PATTERN = re.compile(r"(?:(?<!\\)/u|(?<!/)u)(?<!\\)/\S+")
+UNESCAPED_USERNAME_PATTERN = re.compile(r"(?<!\w)(?:(?<!\\)/u|(?<!/)u)(?<!\\)/\S+")
+
+# Regex to recognized unescaped subreddit names.
+# They need to be escaped with a backslash, otherwise the sub might get pinged.
+# For example, r/subreddit and /u/subreddit are not allowed.
+# Instead, r\/subreddit, \/r/subreddit or \/r\/subreddit should be used.
+UNESCAPED_SUBREDDIT_PATTERN = re.compile(r"(?<!\w)(?:(?<!\\)/r|(?<!/)r)(?<!\\)/\S+")
 
 
 def check_for_bold_header(transcription: str) -> Optional[FormattingIssue]:
@@ -140,6 +146,21 @@ def check_for_unescaped_username(transcription: str) -> Optional[FormattingIssue
     )
 
 
+def check_for_unescaped_subreddit(transcription: str) -> Optional[FormattingIssue]:
+    """Check if the transcription contains an unescaped subreddit name.
+
+    Examples: r/subreddit and /r/subreddit are not allowed.
+    Instead, r\\/subreddit, \\/r/subreddit or \\/r\\/subreddit need to be used.
+
+    Otherwise the subreddit might get pinged.
+    """
+    return (
+        FormattingIssue.UNESCAPED_SUBREDDIT
+        if UNESCAPED_SUBREDDIT_PATTERN.search(transcription) is not None
+        else None
+    )
+
+
 def check_for_formatting_issues(transcription: str) -> Set[FormattingIssue]:
     """Check the transcription for common formatting issues."""
     return set(
@@ -151,6 +172,7 @@ def check_for_formatting_issues(transcription: str) -> Set[FormattingIssue]:
             check_for_missing_separators(transcription),
             check_for_fenced_code_block(transcription),
             check_for_unescaped_username(transcription),
+            check_for_unescaped_subreddit(transcription),
         ]
         if issue is not None
     )

--- a/tor/validation/formatting_validation.py
+++ b/tor/validation/formatting_validation.py
@@ -152,7 +152,6 @@ def check_for_unescaped_username(transcription: str) -> Optional[FormattingIssue
     )
 
 
-
 def check_for_unescaped_subreddit(transcription: str) -> Optional[FormattingIssue]:
     """Check if the transcription contains an unescaped subreddit name.
 

--- a/tor/validation/formatting_validation.py
+++ b/tor/validation/formatting_validation.py
@@ -40,7 +40,13 @@ HEADING_WITH_DASHES_PATTERN = re.compile(r"[\w][:*_ ]*\n[ ]{,3}([-][ ]*){3,}\n")
 # ```
 # int x = 0;
 # ```
-FENCED_CODE_BLOCK_PATTERN = re.compile("```.*```", re.DOTALL)
+FENCED_CODE_BLOCK_PATTERN = re.compile(r"```.*```", re.DOTALL)
+
+# Regex to recognized unescaped usernames.
+# They need to be escaped with a backslash, otherwise the user will be pinged
+# For example, u/username and /u/username are not allowed.
+# Instead, u\/username, \/u/username or \/u\/username should be used.
+UNESCAPED_USERNAME_PATTERN = re.compile(r"(?:(?<!\\)/u|(?<!/)u)(?<!\\)/\S+")
 
 
 def check_for_bold_header(transcription: str) -> Optional[FormattingIssue]:

--- a/tor/validation/formatting_validation.py
+++ b/tor/validation/formatting_validation.py
@@ -125,6 +125,21 @@ def check_for_fenced_code_block(transcription: str) -> Optional[FormattingIssue]
     )
 
 
+def check_for_unescaped_username(transcription: str) -> Optional[FormattingIssue]:
+    """Check if the transcription contains an unescaped username.
+
+    Examples: u/username and /u/username are not allowed.
+    Instead, u\\/username, \\/u/username or \\/u\\/username need to be used.
+
+    Otherwise the user will get pinged.
+    """
+    return (
+        FormattingIssue.UNESCAPED_USERNAME
+        if UNESCAPED_USERNAME_PATTERN.search(transcription) is not None
+        else None
+    )
+
+
 def check_for_formatting_issues(transcription: str) -> Set[FormattingIssue]:
     """Check the transcription for common formatting issues."""
     return set(
@@ -135,6 +150,7 @@ def check_for_formatting_issues(transcription: str) -> Set[FormattingIssue]:
             check_for_heading_with_dashes(transcription),
             check_for_missing_separators(transcription),
             check_for_fenced_code_block(transcription),
+            check_for_unescaped_username(transcription),
         ]
         if issue is not None
     )


### PR DESCRIPTION
Closes #248.

This adds automatic formatting checks for unescaped sub- and usernames, e.g. `u/username` instead of `u\/username`.
If the name is not escaped it pings the user, so we want to avoid that.