### PR TITLE
Add check for unescaped hashtags

### DIFF
--- a/test/validation/test_formatting_validation.py
+++ b/test/validation/test_formatting_validation.py
@@ -180,9 +180,9 @@ def test_check_for_fenced_code_block(test_input: str, should_match: bool) -> Non
 @pytest.mark.parametrize(
     "test_input,should_match",
     [
-        ("#This is an unescaped header", True),
+        ("#This is an unescaped heading", True),
         ("\#This is properly escaped", False),
-        ("# This is meant to render as a header", False),
+        ("# This is meant to render as a heading", False),
         ("\n     \n   #heading", True),
         ("\n\n\#hashtag1 #hashtag2", False),
         ("\n\n*#hashtag1 #hashtag2*", False),

--- a/test/validation/test_formatting_validation.py
+++ b/test/validation/test_formatting_validation.py
@@ -184,8 +184,8 @@ def test_check_for_fenced_code_block(test_input: str, should_match: bool) -> Non
         (r"\#This is properly escaped", False),
         ("# This is meant to render as a heading", False),
         ("\n     \n   #heading", True),
-        (r"\n\n\#hashtag1 #hashtag2", False),
-        (r"\n\n*#hashtag1 #hashtag2*", False),
+        ("\n\n\\#hashtag1 #hashtag2", False),
+        ("\n\n*#hashtag1 #hashtag2*", False),
     ]
 )
 def test_check_for_unescaped_heading(test_input: str, should_match: bool) -> None:

--- a/test/validation/test_formatting_validation.py
+++ b/test/validation/test_formatting_validation.py
@@ -188,7 +188,7 @@ def test_check_for_fenced_code_block(test_input: str, should_match: bool) -> Non
         ("\n\n*#hashtag1 #hashtag2*", False),
     ]
 )
-def test_check_for_unescaped_hashtag(test_input: str, should_match: bool) -> None:
+def test_check_for_unescaped_heading(test_input: str, should_match: bool) -> None:
     """Test if unescaped hashtags are detected."""
     actual = check_for_unescaped_heading(test_input)
     expected = FormattingIssue.UNESCAPED_HEADING if should_match else None

--- a/test/validation/test_formatting_validation.py
+++ b/test/validation/test_formatting_validation.py
@@ -14,6 +14,7 @@ from tor.validation.formatting_validation import (
     check_for_heading_with_dashes,
     check_for_malformed_footer,
     check_for_bold_header,
+    check_for_unescaped_hashtag,
     PROPER_SEPARATORS_PATTERN,
     HEADING_WITH_DASHES_PATTERN,
 )
@@ -173,6 +174,21 @@ def test_check_for_fenced_code_block(test_input: str, should_match: bool) -> Non
     """Test if fenced code blocks are detected."""
     actual = check_for_fenced_code_block(test_input)
     expected = FormattingIssue.FENCED_CODE_BLOCK if should_match else None
+    assert actual == expected
+
+
+@pytest.mark.parametrize(
+    "test_input,should_match",
+    [
+        ("#This is an unescaped header", True),
+        ("\#This is properly escaped", False),
+        ("# This is meant to render as a header", False)
+    ]
+)
+def test_check_for_unescaped_hashtag(test_input: str, should_match: bool) -> None:
+    """Test if unescaped hashtags are detected."""
+    actual = check_for_unescaped_hashtag(test_input)
+    expected = FormattingIssue.UNESCAPED_HEADER if should_match else None
     assert actual == expected
 
 

--- a/test/validation/test_formatting_validation.py
+++ b/test/validation/test_formatting_validation.py
@@ -182,7 +182,10 @@ def test_check_for_fenced_code_block(test_input: str, should_match: bool) -> Non
     [
         ("#This is an unescaped header", True),
         ("\#This is properly escaped", False),
-        ("# This is meant to render as a header", False)
+        ("# This is meant to render as a header", False),
+        ("\n     \n   #heading", True),
+        ("\n\n\#hashtag1 #hashtag2", False),
+        ("\n\n*#hashtag1 #hashtag2*", False),
     ]
 )
 def test_check_for_unescaped_hashtag(test_input: str, should_match: bool) -> None:

--- a/test/validation/test_formatting_validation.py
+++ b/test/validation/test_formatting_validation.py
@@ -14,7 +14,7 @@ from tor.validation.formatting_validation import (
     check_for_heading_with_dashes,
     check_for_malformed_footer,
     check_for_bold_header,
-    check_for_unescaped_hashtag,
+    check_for_unescaped_heading,
     PROPER_SEPARATORS_PATTERN,
     HEADING_WITH_DASHES_PATTERN,
 )
@@ -190,8 +190,8 @@ def test_check_for_fenced_code_block(test_input: str, should_match: bool) -> Non
 )
 def test_check_for_unescaped_hashtag(test_input: str, should_match: bool) -> None:
     """Test if unescaped hashtags are detected."""
-    actual = check_for_unescaped_hashtag(test_input)
-    expected = FormattingIssue.UNESCAPED_HEADER if should_match else None
+    actual = check_for_unescaped_heading(test_input)
+    expected = FormattingIssue.UNESCAPED_HEADING if should_match else None
     assert actual == expected
 
 

--- a/test/validation/test_formatting_validation.py
+++ b/test/validation/test_formatting_validation.py
@@ -181,11 +181,11 @@ def test_check_for_fenced_code_block(test_input: str, should_match: bool) -> Non
     "test_input,should_match",
     [
         ("#This is an unescaped heading", True),
-        ("\#This is properly escaped", False),
+        (r"\#This is properly escaped", False),
         ("# This is meant to render as a heading", False),
         ("\n     \n   #heading", True),
-        ("\n\n\#hashtag1 #hashtag2", False),
-        ("\n\n*#hashtag1 #hashtag2*", False),
+        (r"\n\n\#hashtag1 #hashtag2", False),
+        (r"\n\n*#hashtag1 #hashtag2*", False),
     ]
 )
 def test_check_for_unescaped_heading(test_input: str, should_match: bool) -> None:

--- a/tor/strings/en_US.yml
+++ b/tor/strings/en_US.yml
@@ -259,7 +259,7 @@ formatting_issues:
 
     \    int x = 0;\n
     \   int y = x * 100;"
-  unescaped_heading: "**Unescaped heading syntax**: It looks like you have an unescaped hashtag in your transcription, this may cause it to render as a heading instead of a raw hashtag. For example:
+  unescaped_heading: "**Unescaped heading syntax**: It looks like you have an unescaped heading in your transcription, this may cause it to render as a heading instead of a raw hashtag. For example:
 
 
     \    #Text

--- a/tor/strings/en_US.yml
+++ b/tor/strings/en_US.yml
@@ -259,7 +259,7 @@ formatting_issues:
 
     \    int x = 0;\n
     \   int y = x * 100;"
-  unescaped_heading: "**Unescaped heading syntax**: It looks like you have an unescaped heading in your transcription, this may cause it to render as a heading instead of a raw hashtag. For example:
+  unescaped_heading: "**Unescaped heading syntax**: It looks like you intended to transcribe a hashtag, but made it a heading (big text) instead. This is caused by not escaping the number sign (`#`) in front of the hashtag. For example:
 
 
     \    #Text
@@ -271,7 +271,7 @@ formatting_issues:
     #Text
 
 
-    To fix this, add a backslash in front of the \\# like so: `\\#Text`. If you meant for it to render as a heading, please add a space after the \\# to avoid this warning. i.e. `# Text`."
+    To fix this, add a backslash in front of the `#` like so: `#Text`. If you meant for it to render as a heading, please add a space after the `#` to avoid this warning. i.e. `# Text`."
 urls:
   yt_transcript_url: 'http://video.google.com/timedtext?lang=en&v={}'
   ToR_link: 'www.reddit.com/r/TranscribersOfReddit'

--- a/tor/strings/en_US.yml
+++ b/tor/strings/en_US.yml
@@ -259,6 +259,15 @@ formatting_issues:
 
     \    int x = 0;\n
     \   int y = x * 100;"
+  unescaped_header: "**Unescaped header syntax**: It looks like you have an escaped hashtag in your transcription, this may cause it to render as a header instead of a raw hashtag. For example:
+
+    \    #Text
+
+    would render as:
+
+    #Text
+
+    To fix this, add a backslash in front of the \\# like so: `\\#Text`. If you meant for it to render as a header, please add a space after the \\# to avoid this warning. i.e. `# Text`."
 urls:
   yt_transcript_url: 'http://video.google.com/timedtext?lang=en&v={}'
   ToR_link: 'www.reddit.com/r/TranscribersOfReddit'

--- a/tor/strings/en_US.yml
+++ b/tor/strings/en_US.yml
@@ -261,11 +261,15 @@ formatting_issues:
     \   int y = x * 100;"
   unescaped_header: "**Unescaped header syntax**: It looks like you have an escaped hashtag in your transcription, this may cause it to render as a header instead of a raw hashtag. For example:
 
+
     \    #Text
+
 
     would render as:
 
+
     #Text
+
 
     To fix this, add a backslash in front of the \\# like so: `\\#Text`. If you meant for it to render as a header, please add a space after the \\# to avoid this warning. i.e. `# Text`."
 urls:

--- a/tor/strings/en_US.yml
+++ b/tor/strings/en_US.yml
@@ -259,7 +259,7 @@ formatting_issues:
 
     \    int x = 0;\n
     \   int y = x * 100;"
-  unescaped_header: "**Unescaped header syntax**: It looks like you have an escaped hashtag in your transcription, this may cause it to render as a header instead of a raw hashtag. For example:
+  unescaped_heading: "**Unescaped heading syntax**: It looks like you have an unescaped hashtag in your transcription, this may cause it to render as a heading instead of a raw hashtag. For example:
 
 
     \    #Text
@@ -271,7 +271,7 @@ formatting_issues:
     #Text
 
 
-    To fix this, add a backslash in front of the \\# like so: `\\#Text`. If you meant for it to render as a header, please add a space after the \\# to avoid this warning. i.e. `# Text`."
+    To fix this, add a backslash in front of the \\# like so: `\\#Text`. If you meant for it to render as a heading, please add a space after the \\# to avoid this warning. i.e. `# Text`."
 urls:
   yt_transcript_url: 'http://video.google.com/timedtext?lang=en&v={}'
   ToR_link: 'www.reddit.com/r/TranscribersOfReddit'

--- a/tor/validation/formatting_issues.py
+++ b/tor/validation/formatting_issues.py
@@ -7,4 +7,4 @@ class FormattingIssue(Enum):
     HEADING_WITH_DASHES = "heading_with_dashes"
     MALFORMED_FOOTER = "malformed_footer"
     FENCED_CODE_BLOCK = "fenced_code_block"
-    UNESCAPED_HEADER = "unescaped_header"
+    UNESCAPED_HEADING = "unescaped_heading"

--- a/tor/validation/formatting_issues.py
+++ b/tor/validation/formatting_issues.py
@@ -7,3 +7,4 @@ class FormattingIssue(Enum):
     HEADING_WITH_DASHES = "heading_with_dashes"
     MALFORMED_FOOTER = "malformed_footer"
     FENCED_CODE_BLOCK = "fenced_code_block"
+    UNESCAPED_HEADER = "unescaped_header"

--- a/tor/validation/formatting_validation.py
+++ b/tor/validation/formatting_validation.py
@@ -42,6 +42,12 @@ HEADING_WITH_DASHES_PATTERN = re.compile(r"[\w][:*_ ]*\n[ ]{,3}([-][ ]*){3,}\n")
 # ```
 FENCED_CODE_BLOCK_PATTERN = re.compile("```.*```", re.DOTALL)
 
+# Regex to recognize unescaped hashtags which may render as headers.
+# Example:
+#
+# #Hashtag
+UNESCAPED_HEADER_PATTERN = re.compile(r"([^\\]|^)#[^ ].*")
+
 
 def check_for_bold_header(transcription: str) -> Optional[FormattingIssue]:
     """Check if the transcription has a bold instead of italic header."""
@@ -115,6 +121,21 @@ def check_for_fenced_code_block(transcription: str) -> Optional[FormattingIssue]
     return (
         FormattingIssue.FENCED_CODE_BLOCK
         if FENCED_CODE_BLOCK_PATTERN.search(transcription) is not None
+        else None
+    )
+
+
+def check_for_unescaped_hashtag(transcription: str) -> Optional[FormattingIssue]:
+    """Check if the transcription contains an unescaped hashtag. Actual backslash in example swapped for (backslash) to
+    avoid invalid escape sequence warning
+
+    Valid: (backslash)#Text
+    Valid: # Test
+    Invalid: #Test
+    """
+    return (
+        FormattingIssue.UNESCAPED_HEADER
+        if UNESCAPED_HEADER_PATTERN.search(transcription) is not None
         else None
     )
 

--- a/tor/validation/formatting_validation.py
+++ b/tor/validation/formatting_validation.py
@@ -46,7 +46,7 @@ FENCED_CODE_BLOCK_PATTERN = re.compile("```.*```", re.DOTALL)
 # Example:
 #
 # #Hashtag
-UNESCAPED_HEADING_PATTERN = re.compile(r"([^\\]|^)#[^ ].*")
+UNESCAPED_HEADING_PATTERN = re.compile(r"(\n[ ]*\n[ ]{,3}|^)#[^ ].*")
 
 
 def check_for_bold_header(transcription: str) -> Optional[FormattingIssue]:

--- a/tor/validation/formatting_validation.py
+++ b/tor/validation/formatting_validation.py
@@ -46,7 +46,7 @@ FENCED_CODE_BLOCK_PATTERN = re.compile("```.*```", re.DOTALL)
 # Example:
 #
 # #Hashtag
-UNESCAPED_HEADER_PATTERN = re.compile(r"([^\\]|^)#[^ ].*")
+UNESCAPED_HEADING_PATTERN = re.compile(r"([^\\]|^)#[^ ].*")
 
 
 def check_for_bold_header(transcription: str) -> Optional[FormattingIssue]:
@@ -125,7 +125,7 @@ def check_for_fenced_code_block(transcription: str) -> Optional[FormattingIssue]
     )
 
 
-def check_for_unescaped_hashtag(transcription: str) -> Optional[FormattingIssue]:
+def check_for_unescaped_heading(transcription: str) -> Optional[FormattingIssue]:
     """Check if the transcription contains an unescaped hashtag. Actual backslash in example swapped for (backslash) to
     avoid invalid escape sequence warning
 
@@ -134,8 +134,8 @@ def check_for_unescaped_hashtag(transcription: str) -> Optional[FormattingIssue]
     Invalid: #Test
     """
     return (
-        FormattingIssue.UNESCAPED_HEADER
-        if UNESCAPED_HEADER_PATTERN.search(transcription) is not None
+        FormattingIssue.UNESCAPED_HEADING
+        if UNESCAPED_HEADING_PATTERN.search(transcription) is not None
         else None
     )
 

--- a/tor/validation/formatting_validation.py
+++ b/tor/validation/formatting_validation.py
@@ -46,7 +46,7 @@ FENCED_CODE_BLOCK_PATTERN = re.compile("```.*```", re.DOTALL)
 # Example:
 #
 # #Hashtag
-UNESCAPED_HEADING_PATTERN = re.compile(r"(\n[ ]*\n[ ]{,3}|^)#[^ ].*")
+UNESCAPED_HEADING_PATTERN = re.compile(r"(\n[ ]*\n[ ]{,3}|^)#[^ ]")
 
 
 def check_for_bold_header(transcription: str) -> Optional[FormattingIssue]:


### PR DESCRIPTION
Closes #254 

This adds automatic formatting checks for unescaped header markdown, e.g. \#username instead of \\\#username.