### PR TITLE
Fix the bot crashing when a heading with dashes is detected

### DIFF
--- a/tor/strings/en_US.yml
+++ b/tor/strings/en_US.yml
@@ -212,7 +212,7 @@ formatting_issues:
     \   ---\n
     \   \n
     \   <footer>"
-  separator_headings: "**Separator as heading**: It seems like you meant to make a horizontal separator (`---`), but have created a heading instead.
+  heading_with_dashes: "**Heading with dashes**: It seems like you meant to make a horizontal separator (`---`), but have created a heading (i.e. 'big text') instead.
 
     The separators require an empty line before and after it, like this:
 


### PR DESCRIPTION
The localization key for the `heading_with_dashes` issue had the wrong name.
This caused the bot to crash when assembling the reply, resulting in the volunteer not being notified and spamming the mod Slack with messages.