### PR TITLE
Add title mention for Reddit galleries

### DIFF
--- a/tor/core/posts.py
+++ b/tor/core/posts.py
@@ -37,7 +37,11 @@ def process_post(new_post: PostSummary, cfg: Config) -> None:
         f'Posting call for transcription on ID {new_post["name"]} posted by {new_post["author"]}'
     )
 
-    if new_post["domain"] in cfg.image_domains:
+    if new_post["is_gallery"]:
+        content_type = "gallery"
+        content_format = cfg.image_formatting
+
+    elif new_post["domain"] in cfg.image_domains:
         content_type = "image"
         content_format = cfg.image_formatting
 
@@ -48,6 +52,7 @@ def process_post(new_post: PostSummary, cfg: Config) -> None:
     elif new_post["domain"] in cfg.video_domains:
         content_type = "video"
         content_format = cfg.video_formatting
+
     else:
         # This means we pulled from a subreddit bypassing the filters.
         content_type = "Other"

--- a/tor/helpers/threaded_worker.py
+++ b/tor/helpers/threaded_worker.py
@@ -69,7 +69,7 @@ def get_subreddit_posts(sub: str) -> List[PostSummary]:
                     'title': item['title'],
                     'permalink': item['permalink'],
                     'is_nsfw': item['over_18'],
-                    'is_gallery': hasattr(item, 'is_gallery'),
+                    'is_gallery': "is_gallery" in item,
                     'domain': item['domain'],
                     'ups': item['ups'],
                     'locked': item['locked'],

--- a/tor/helpers/threaded_worker.py
+++ b/tor/helpers/threaded_worker.py
@@ -69,6 +69,7 @@ def get_subreddit_posts(sub: str) -> List[PostSummary]:
                     'title': item['title'],
                     'permalink': item['permalink'],
                     'is_nsfw': item['over_18'],
+                    'is_gallery': hasattr(item, 'is_gallery'),
                     'domain': item['domain'],
                     'ups': item['ups'],
                     'locked': item['locked'],


### PR DESCRIPTION
Closes #196 

Mentions that the post has a Reddit image gallery (doesn't work for Imgur as far as I know) in the title of the ToR post, currently has the formatting as image formatting but it could be changed to have a different bot comment.

Works by checking if the `is_gallery` key is present in the JSON response Reddit returns, it's only present when the image is a gallery. [Example of data](http://img.theodorehua.dev/4IiAvdDs). 

The logic is all very simple but I haven't been able to test it locally.