### PR TITLE
Call unescaped heading check

### DIFF
--- a/test/validation/test_formatting_validation.py
+++ b/test/validation/test_formatting_validation.py
@@ -220,6 +220,12 @@ def test_check_for_unescaped_heading(test_input: str, should_match: bool) -> Non
                 FormattingIssue.MISSING_SEPARATORS,
             ],
         ),
+        (
+            load_invalid_transcription_from_file("unescaped-heading.txt"),
+            [
+                FormattingIssue.UNESCAPED_HEADING
+            ]
+        )
     ],
 )
 def test_check_for_formatting_issues_invalid_transcriptions(

--- a/test/validation/transcriptions/invalid/unescaped-heading.txt
+++ b/test/validation/transcriptions/invalid/unescaped-heading.txt
@@ -1,0 +1,11 @@
+*Image Transcription:*
+
+---
+
+Blah blah
+
+#I hate bugs
+
+---
+
+^^I'm&#32;a&#32;human&#32;volunteer&#32;content&#32;transcriber&#32;for&#32;Reddit&#32;and&#32;you&#32;could&#32;be&#32;too!&#32;[If&#32;you'd&#32;like&#32;more&#32;information&#32;on&#32;what&#32;we&#32;do&#32;and&#32;why&#32;we&#32;do&#32;it,&#32;click&#32;here!](https://www.reddit.com/r/TranscribersOfReddit/wiki/index)

--- a/tor/validation/formatting_validation.py
+++ b/tor/validation/formatting_validation.py
@@ -150,6 +150,7 @@ def check_for_formatting_issues(transcription: str) -> Set[FormattingIssue]:
             check_for_heading_with_dashes(transcription),
             check_for_missing_separators(transcription),
             check_for_fenced_code_block(transcription),
+            check_for_unescaped_heading(transcription),
         ]
         if issue is not None
     )


### PR DESCRIPTION
In relation to #263 

The check implemented in that PR wasn't actually called in the `check_formatting_issues` function.