### PR TITLE
Add formatting check for missing or invalid header

### DIFF
--- a/test/validation/test_formatting_validation.py
+++ b/test/validation/test_formatting_validation.py
@@ -15,6 +15,7 @@ from tor.validation.formatting_validation import (
     check_for_malformed_footer,
     check_for_bold_header,
     check_for_unescaped_heading,
+    check_for_invalid_header,
     PROPER_SEPARATORS_PATTERN,
     HEADING_WITH_DASHES_PATTERN,
 )
@@ -193,6 +194,25 @@ def test_check_for_unescaped_heading(test_input: str, should_match: bool) -> Non
     """Test if unescaped hashtags are detected."""
     actual = check_for_unescaped_heading(test_input)
     expected = FormattingIssue.UNESCAPED_HEADING if should_match else None
+    assert actual == expected
+
+
+@pytest.mark.parametrize(
+    "test_input,should_match",
+    [
+        ("*Image Transcription: Test*", False),
+        ("*Image Transcription*", False),
+        ("*Audio Transcription*", False),
+        ("*Video Transcription*", False),
+        ("*Invalid Header*", True),
+        ("*Invalid Header*\n\n---\n\nBlah", True),
+        ("*Image Transcription: Test*\n\n---\n\nBlah", False)
+    ]
+)
+def test_check_for_invalid_header(test_input: str, should_match: bool) -> None:
+    """Test if invalid headers are detected."""
+    actual = check_for_invalid_header(test_input)
+    expected = FormattingIssue.INVALID_HEADER if should_match else None
     assert actual == expected
 
 

--- a/tor/strings/en_US.yml
+++ b/tor/strings/en_US.yml
@@ -272,6 +272,13 @@ formatting_issues:
 
 
     To fix this, add a backslash in front of the `#` like so: `#Text`. If you meant for it to render as a heading, please add a space after the `#` to avoid this warning. i.e. `# Text`."
+  invalid_header: "**Invalid header**: It looks like your header doesn't contain a proper type (Image, Video, or Audio) or is missing italics. Please make sure your post contains a proper header. For example if it's an Image Transcription, it should be the following:
+
+
+    \   *Image Transcription: Example*
+
+
+    same goes for Video or Audio (but with the word `Image` replaced)."
 urls:
   yt_transcript_url: 'http://video.google.com/timedtext?lang=en&v={}'
   ToR_link: 'www.reddit.com/r/TranscribersOfReddit'

--- a/tor/strings/en_US.yml
+++ b/tor/strings/en_US.yml
@@ -272,7 +272,7 @@ formatting_issues:
 
 
     To fix this, add a backslash in front of the `#` like so: `#Text`. If you meant for it to render as a heading, please add a space after the `#` to avoid this warning. i.e. `# Text`."
-  invalid_header: "**Invalid header**: It looks like your header doesn't contain a proper type (Image, Video, or Audio) or is missing italics. Please make sure your post contains a proper header. For example if it's an Image Transcription, it should be the following:
+  invalid_header: "**Invalid header**: It looks like your header doesn't contain a proper type (Image, Video, or Audio) or is missing italics. Please make sure your post contains a proper header. For example if it's an Image Transcription, it should be the following at the top of your transcription:
 
 
     \   *Image Transcription: Example*

--- a/tor/validation/formatting_issues.py
+++ b/tor/validation/formatting_issues.py
@@ -8,3 +8,4 @@ class FormattingIssue(Enum):
     MALFORMED_FOOTER = "malformed_footer"
     FENCED_CODE_BLOCK = "fenced_code_block"
     UNESCAPED_HEADING = "unescaped_heading"
+    INVALID_HEADER = "invalid_header"

--- a/tor/validation/formatting_validation.py
+++ b/tor/validation/formatting_validation.py
@@ -156,7 +156,7 @@ def check_for_invalid_header(transcription: str) -> Optional[FormattingIssue]:
     header = transcription.split("---")[0]
     return (
         FormattingIssue.INVALID_HEADER
-        if not any([True for i in VALID_HEADERS if re.search(r"\*{}.*\*".format(i), header) is not None])
+        if not any([re.search(r"\*{}.*\*".format(i), header) is not None for i in VALID_HEADERS])
         else None
     )
 

--- a/tor/validation/formatting_validation.py
+++ b/tor/validation/formatting_validation.py
@@ -48,6 +48,12 @@ FENCED_CODE_BLOCK_PATTERN = re.compile("```.*```", re.DOTALL)
 # #Hashtag
 UNESCAPED_HEADING_PATTERN = re.compile(r"(\n[ ]*\n[ ]{,3}|^)#{1,6}[^ #]")
 
+# List of valid headers for the start of the transcription
+# Example
+#
+# Image Transcription
+VALID_HEADERS = ["Audio Transcription", "Image Transcription", "Video Transcription"]
+
 
 def check_for_bold_header(transcription: str) -> Optional[FormattingIssue]:
     """Check if the transcription has a bold instead of italic header."""
@@ -140,6 +146,21 @@ def check_for_unescaped_heading(transcription: str) -> Optional[FormattingIssue]
     )
 
 
+def check_for_invalid_header(transcription: str) -> Optional[FormattingIssue]:
+    """Check if the transcription contains a valid header option (Image, Video, or Audio).
+
+    Valid: *Video Transcription: Test*
+    Valid: *Image Transcription*
+    Invalid: *Random Transcription*
+    """
+    header = transcription.split("---")[0]
+    return (
+        FormattingIssue.INVALID_HEADER
+        if not any([True for i in VALID_HEADERS if re.search(r"\*{}.*\*".format(i), header) is not None])
+        else None
+    )
+
+
 def check_for_formatting_issues(transcription: str) -> Set[FormattingIssue]:
     """Check the transcription for common formatting issues."""
     return set(
@@ -151,6 +172,7 @@ def check_for_formatting_issues(transcription: str) -> Set[FormattingIssue]:
             check_for_missing_separators(transcription),
             check_for_fenced_code_block(transcription),
             check_for_unescaped_heading(transcription),
+            check_for_invalid_header(transcription),
         ]
         if issue is not None
     )


### PR DESCRIPTION
Closes #271 

The code checks if a header of valid type (Image, Video, or Audio) is present in the transcription, using the regex `\*<type>.*\*` (replace `<type>` with valid headers, such as `Image Transcription`) searching above the first separator.

The issue also suggested putting the exact header type the transcription should have in the issue message (e.g. post is an Video, then it should suggest the transcriber put `Video Transcription`).   
I don't really see a good way of doing this as the formatting testing and formatting issue message functions only receive the transcription as a string and not a Reddit or Blossom object (which could be used to get the type from the title or a parameter). I'm more than happy to get proved wrong though.