### PR TITLE
Relax footer check to not require empty line after separator

### DIFF
--- a/test/validation/transcriptions/valid/377970.txt
+++ b/test/validation/transcriptions/valid/377970.txt
@@ -1,0 +1,10 @@
+*Image Transcription: Twitter*
+
+---
+
+> **Lena Emara**, @LenaEmara
+>
+> My favorite part of WFH is watching my husband silently clap his hands on celebratory calls so as not to disturb the peace
+
+---
+ ^^I'm&#32;a&#32;human&#32;volunteer&#32;content&#32;transcriber&#32;for&#32;Reddit&#32;and&#32;you&#32;could&#32;be&#32;too!&#32;[If&#32;you'd&#32;like&#32;more&#32;information&#32;on&#32;what&#32;we&#32;do&#32;and&#32;why&#32;we&#32;do&#32;it,&#32;click&#32;here!](https://www.reddit.com/r/TranscribersOfReddit/wiki/index)

--- a/tor/validation/formatting_validation.py
+++ b/tor/validation/formatting_validation.py
@@ -24,7 +24,7 @@ BOLD_HEADER_PATTERN = re.compile(r"^\s*\*\*(Image|Video|Audio) Transcription:?.*
 # Separators are three dashes (---), potentially with spaces in-between.
 # They need to be surrounded by empty lines (which can contain spaces)
 # The separator line (---) can start with up to three spaces and end with arbitrary spaces.
-PROPER_SEPARATORS_PATTERN = re.compile(r"\n[ ]*\n[ ]{,3}([-][ ]*){3,}[ ]*\n[ ]*\n")
+PROPER_SEPARATORS_PATTERN = re.compile(r"\n[ ]*\n[ ]{,3}([-][ ]*){3,}\n")
 
 # Regex to recognize a separator (---) being misused as heading.
 # This happens when they empty line before the separator is missing.


### PR DESCRIPTION
Closes #290.

This relaxes the separator detection to not require an empty line after the separator.

They should still render correctly on both old and new Reddit.

Some volunteers got confused when this got rejected (because they can't see the difference), so this should help with that.