### PR TITLE
Hotfix: Fix cloning of posts

### DIFF
--- a/test/core/test_helpers.py
+++ b/test/core/test_helpers.py
@@ -1,0 +1,9 @@
+from tor.core.helpers import cleanup_post_title
+
+
+def test_cleanup_post_title() -> None:
+    """Verify that the post title is cleaned up correctly."""
+    title = "Test &amp; other stuff &lt;3 1 &gt; 2 abc"
+    expected = "Test & other stuff <3 1 > 2 abc"
+    actual = cleanup_post_title(title)
+    assert actual == expected

--- a/tor/core/helpers.py
+++ b/tor/core/helpers.py
@@ -295,3 +295,18 @@ def remove_if_required(
             mod_message.format(submission.shortlink), cfg, channel="removed_posts"
         )
     return removal, reported
+
+
+def cleanup_post_title(title: str) -> str:
+    """Clean up the given post title.
+
+    The Reddit API converts the following characters in responses:
+    - & becomes &amp;
+    - < becomes &lt;
+    - > becomes &gt;
+
+    See https://www.reddit.com/dev/api
+
+    This function reverts this conversion, to display the characters correctly again.
+    """
+    return title.replace("&amp;", "&").replace("&lt;", "<").replace("&gt;", ">")

--- a/tor/core/posts.py
+++ b/tor/core/posts.py
@@ -6,7 +6,7 @@ from blossom_wrapper import BlossomStatus
 from praw.models import Submission
 
 from tor.core.config import Config
-from tor.core.helpers import _
+from tor.core.helpers import _, cleanup_post_title
 from tor.helpers.flair import flair, flair_post
 from tor.helpers.youtube import (
     is_transcribable_youtube_video,
@@ -116,7 +116,7 @@ def request_transcription(
     title = i18n["posts"]["discovered_submit_title"].format(
         sub=str(post["subreddit"]),
         type=content_type.title(),
-        title=truncate_title(str(post["title"])),
+        title=truncate_title(cleanup_post_title(str(post["title"]))),
     )
     permalink = i18n["urls"]["reddit_url"].format(str(post["permalink"]))
     submission = cfg.tor.submit(title=title, url=permalink)
@@ -142,7 +142,7 @@ def create_blossom_submission(
         tor_url,
         original_url,
         content_url,
-        post_title=original_post["title"],
+        post_title=cleanup_post_title(original_post["title"]),
         nsfw=original_post["is_nsfw"],
     )
 

--- a/tor/core/posts.py
+++ b/tor/core/posts.py
@@ -142,7 +142,7 @@ def create_blossom_submission(
         tor_url,
         original_url,
         content_url,
-        post_title=cleanup_post_title(original_post["title"]),
+        post_title=cleanup_post_title(str(original_post["title"])),
         nsfw=original_post["is_nsfw"],
     )
 


### PR DESCRIPTION
Closes #297.

This fixes the cloning of posts by reverting the encoding of `&`, `<` and `>`.
Otherwise, the post title might be too long for Blossom to handle.