### PR TITLE
Rework submission flairing

### DIFF
--- a/tor/core/helpers.py
+++ b/tor/core/helpers.py
@@ -15,6 +15,9 @@ from tor.core import __version__
 from tor.core.config import config, Config
 from tor.helpers.reddit_ids import is_removed
 from tor.strings import translation
+from dotenv import load_dotenv
+
+load_dotenv()
 
 log = logging.getLogger(__name__)
 
@@ -23,12 +26,20 @@ i18n = translation()
 
 
 class flair(object):
-    unclaimed = "Unclaimed"
-    summoned_unclaimed = "Summoned - Unclaimed"
-    completed = "Completed!"
-    in_progress = "In Progress"
-    meta = "Meta"
-    disregard = "Disregard"
+    """The IDs of the post flairs.
+
+    You can define these in your .env file.
+
+    How to obtain the IDs?
+    Go to https://new.reddit.com/r/TranscribersOfReddit/about/postflair
+    and click "COPY ID" for the given flairs.
+    """
+
+    unclaimed = os.getenv("UNCLAIMED_FLAIR_ID")
+    in_progress = os.getenv("IN_PROGRESS_FLAIR_ID")
+    completed = os.getenv("COMPLETED_FLAIR_ID")
+    meta = os.getenv("META_FLAIR_ID")
+    disregard = os.getenv("DISREGARD_FLAIR_ID")
 
 
 class reports(object):

--- a/tor/core/helpers.py
+++ b/tor/core/helpers.py
@@ -4,6 +4,7 @@ import signal
 import sys
 import time
 from typing import List, Tuple
+import os
 
 import beeline
 from praw.exceptions import APIException

--- a/tor/core/posts.py
+++ b/tor/core/posts.py
@@ -119,12 +119,11 @@ def request_transcription(
         title=truncate_title(cleanup_post_title(str(post["title"]))),
     )
     permalink = i18n["urls"]["reddit_url"].format(str(post["permalink"]))
-    submission = cfg.tor.submit(title=title, url=permalink)
+    submission = cfg.tor.submit(title=title, url=permalink, flair_id=flair.unclaimed)
     intro = i18n["posts"]["rules_comment"].format(
         post_type=content_type, formatting=content_format, header=cfg.header,
     )
     submission.reply(_(intro))
-    flair_post(submission, flair.unclaimed)
     create_blossom_submission(post, submission, cfg)
 
 

--- a/tor/core/posts.py
+++ b/tor/core/posts.py
@@ -7,7 +7,7 @@ from praw.models import Submission
 
 from tor.core.config import Config
 from tor.core.helpers import _, cleanup_post_title
-from tor.helpers.flair import flair, flair_post
+from tor.helpers.flair import flair
 from tor.helpers.youtube import (
     is_transcribable_youtube_video,
     is_youtube_url,

--- a/tor/helpers/flair.py
+++ b/tor/helpers/flair.py
@@ -122,7 +122,7 @@ def set_meta_flair_on_other_posts(cfg: Config) -> None:
             continue
         if str(post.author) in cfg.tor_mods:
             continue
-        if post.link_flair_text == flair.meta:
+        if post.link_flair_template_id == flair.meta:
             continue
 
         log.info(f"Flairing post {post.fullname} by author {post.author} with Meta.")

--- a/tor/helpers/flair.py
+++ b/tor/helpers/flair.py
@@ -1,5 +1,6 @@
 import logging
 import random
+from typing import Optional
 
 from blossom_wrapper import BlossomStatus
 from praw.models import Comment, Redditor, Submission
@@ -27,7 +28,7 @@ FLAIR_DATA = {
 }
 
 
-def flair_post(post: Submission, flair_id: str) -> None:
+def flair_post(post: Submission, flair_id: Optional[str]) -> None:
     """
     Sets the requested flair on a given post.
 
@@ -36,6 +37,13 @@ def flair_post(post: Submission, flair_id: str) -> None:
     You can use the flair class to select the flair ID.
     :return: None.
     """
+    if not flair_id:
+        log.error(
+            "Trying to flair post without providing a flair ID. "
+            "Did you set the .env variables?"
+        )
+        return
+
     post.flair.select(flair_template_id=flair_id)
 
 

--- a/tor/helpers/flair.py
+++ b/tor/helpers/flair.py
@@ -27,30 +27,16 @@ FLAIR_DATA = {
 }
 
 
-def flair_post(post: Submission, text: str) -> None:
+def flair_post(post: Submission, flair_id: str) -> None:
     """
-    Sets the requested flair on a given post. Must provide a string
-    which matches an already-available flair template.
+    Sets the requested flair on a given post.
 
     :param post: A Submission object on ToR.
-    :param text: String. The name of the flair template to apply.
+    :param flair_id: String. The ID of the flair template to apply.
+    You can use the flair class to select the flair ID.
     :return: None.
     """
-    # Flair looks like this:
-    # {
-    #   'flair_css_class': 'unclaimed-flair',
-    #   'flair_template_id': 'fe9d6950-142a-11e7-901e-0ecc947f9ff4',
-    #   'flair_text_editable': False,
-    #   'flair_position': 'left',
-    #   'flair_text': 'Unclaimed'
-    # }
-    for choice in post.flair.choices():
-        if choice["flair_text"] == text:
-            post.flair.select(flair_template_id=choice["flair_template_id"])
-            return
-
-    # if the flairing is successful, we won't hit this line.
-    log.error(f"Cannot find requested flair {text}. Not flairing.")
+    post.flair.select(flair_template_id=flair_id)
 
 
 def _get_flair_css(transcription_count: int) -> str:


### PR DESCRIPTION
Closes #278.

This contains two main changes:
- The flair template IDs are now provided via .env variables. This avoids the runtime overhead of determining the ID, which could potentially include API calls.
- When a new transcription is requested, the corresponding post is flaired directly when posting. This saves an API call and could prevent most cases of post duplication in the queue.
All in all, this should make the bot more robust, with the downside of us having to define the template IDs in advance.
Furtunately, this isn't hard to do at all.

:warning: This is a breaking change. The following variables have to be added to the `.env` file: :warning: 
- `UNCLAIMED_FLAIR_ID`
- `IN_PROGRESS_FLAIR_ID`
- `COMPLETED_FLAIR_ID`
- `META_FLAIR_ID`
- `DISREGARD_FLAIR_ID`

The bot should also be monitored after deployment to verify that this didn't break anything.