### PR TITLE
Track timestamp of last reddit post before sending to mod chat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [UNRELEASED]
 
+- Track timestamp of last reddit post processed before sending to mod chat (credit: @crhopkins)
+
 ## [4.2.4] - 2021-04-05
 
 - Odd error with PRAW necessitates a core library upgrade

--- a/tor/core/config.py
+++ b/tor/core/config.py
@@ -41,6 +41,7 @@ class Config(object):
     debug_mode = False
 
     last_post_scan_time = datetime.datetime(1970, 1, 1, 1, 1, 1)
+    last_set_meta_flair_time = datetime.datetime(1970, 1, 1, 1, 1, 1)
 
     @cached_property
     def blossom(self):

--- a/tor/helpers/flair.py
+++ b/tor/helpers/flair.py
@@ -1,6 +1,5 @@
 import logging
 import random
-from datetime import datetime
 
 from blossom_wrapper import BlossomStatus
 from praw.models import Comment, Redditor, Submission
@@ -150,5 +149,5 @@ def set_meta_flair_on_other_posts(cfg: Config) -> None:
         log.info(f"Flairing post {post.fullname} by author {post.author} with Meta.")
         flair_post(post, flair.meta)
         send_to_modchat(f"New meta post: <{post.shortlink}|{post.title}>", cfg)
-        
+
     cfg.last_set_meta_flair_time = new_last_time

--- a/tor/helpers/flair.py
+++ b/tor/helpers/flair.py
@@ -1,5 +1,6 @@
 import logging
 import random
+from datetime import datetime
 
 from blossom_wrapper import BlossomStatus
 from praw.models import Comment, Redditor, Submission
@@ -131,6 +132,8 @@ def set_meta_flair_on_other_posts(cfg: Config) -> None:
     :param cfg: the active config object.
     :return: None.
     """
+
+    new_last_time = cfg.last_set_meta_flair_time
     for post in cfg.tor.new(limit=10):
         if str(post.author) in __BOT_NAMES__:
             continue
@@ -139,6 +142,13 @@ def set_meta_flair_on_other_posts(cfg: Config) -> None:
         if post.link_flair_text == flair.meta:
             continue
 
+        # Skip this post if it older than the last post we processed
+        if post.created_utc < cfg.last_set_meta_flair_time:
+            continue
+
+        new_last_time = max(new_last_time, post.created_utc)
         log.info(f"Flairing post {post.fullname} by author {post.author} with Meta.")
         flair_post(post, flair.meta)
         send_to_modchat(f"New meta post: <{post.shortlink}|{post.title}>", cfg)
+        
+    cfg.last_set_meta_flair_time = new_last_time


### PR DESCRIPTION
Closes #303 

Adds last_set_meta_flair_time to Config object.

last_set_meta_flair_time tracks the timestamp of the last reddit post processed by set_meta_flair_on_other_posts(). 

set_meta_flair_on_other_posts() will skip a post if the post's created_utc timestamp from reddit is before cfg.last_set_meta_flair_time. after processing all the posts, cfg.last_set_meta_flair_time is updated to newest posts created_utc timestamp.