### PR TITLE
Disallow characters prior to the header

### DIFF
--- a/test/validation/test_formatting_validation.py
+++ b/test/validation/test_formatting_validation.py
@@ -337,7 +337,9 @@ def test_check_for_unescaped_heading(test_input: str, should_match: bool) -> Non
         ("*Invalid Header*\n\n---\n\nBlah", True),
         ("*Image Transcription: Test*\n\n---\n\nBlah", False),
         ("Blah *Image Transcription: Test*", True),
-        ("**Image Transcription: Test**", False)  # There is a separate check for this, so it shouldn't be checked here
+        ("**Image Transcription: Test**", False),  # There is a separate check for this, so it shouldn't be checked here
+        ("Image Transcription: Test*", True),
+        ("    *Image Transcription: Test*", False)
     ]
 )
 def test_check_for_invalid_header(test_input: str, should_match: bool) -> None:

--- a/test/validation/test_formatting_validation.py
+++ b/test/validation/test_formatting_validation.py
@@ -206,7 +206,9 @@ def test_check_for_unescaped_heading(test_input: str, should_match: bool) -> Non
         ("*Video Transcription*", False),
         ("*Invalid Header*", True),
         ("*Invalid Header*\n\n---\n\nBlah", True),
-        ("*Image Transcription: Test*\n\n---\n\nBlah", False)
+        ("*Image Transcription: Test*\n\n---\n\nBlah", False),
+        ("Blah *Image Transcription: Test*", True),
+        ("**Image Transcription: Test**", False)  # There is a separate check for this, so it shouldn't be checked here
     ]
 )
 def test_check_for_invalid_header(test_input: str, should_match: bool) -> None:

--- a/tor/strings/en_US.yml
+++ b/tor/strings/en_US.yml
@@ -324,7 +324,7 @@ formatting_issues:
   invalid_header: "**Invalid header**: It looks like your header doesn't contain a proper type (Image, Video, or Audio), is missing italics, and/or is not at the start of your transcription. Please make sure your post contains a proper header at the start of your transcription. For example if it's an Image Transcription, it should be the following at the start of your transcription:
 
 
-    \   *Image Transcription: Example*
+    \    *Image Transcription: Example*
 
 
     same goes for Video or Audio (but with the word `Image` replaced)."

--- a/tor/strings/en_US.yml
+++ b/tor/strings/en_US.yml
@@ -321,7 +321,7 @@ formatting_issues:
 
 
     To fix this, add a backslash in front of the `#` like so: `#Text`. If you meant for it to render as a heading, please add a space after the `#` to avoid this warning. i.e. `# Text`."
-  invalid_header: "**Invalid header**: It looks like your header doesn't contain a proper type (Image, Video, or Audio) or is missing italics. Please make sure your post contains a proper header. For example if it's an Image Transcription, it should be the following at the top of your transcription:
+  invalid_header: "**Invalid header**: It looks like your header doesn't contain a proper type (Image, Video, or Audio), is missing italics, and/or is not at the start of your transcription. Please make sure your post contains a proper header at the start of your transcription. For example if it's an Image Transcription, it should be the following at the start of your transcription:
 
 
     \   *Image Transcription: Example*

--- a/tor/validation/formatting_validation.py
+++ b/tor/validation/formatting_validation.py
@@ -152,11 +152,12 @@ def check_for_invalid_header(transcription: str) -> Optional[FormattingIssue]:
     Valid: *Video Transcription: Test*
     Valid: *Image Transcription*
     Invalid: *Random Transcription*
+    Invalid: Test *Image Transcription*
     """
     header = transcription.split("---")[0]
     return (
         FormattingIssue.INVALID_HEADER
-        if not any([re.search(r"\*{}.*\*".format(i), header) is not None for i in VALID_HEADERS])
+        if not any([re.search(r"^\**{}.*\*".format(i), header) is not None for i in VALID_HEADERS])
         else None
     )
 

--- a/tor/validation/formatting_validation.py
+++ b/tor/validation/formatting_validation.py
@@ -159,7 +159,7 @@ def check_for_invalid_header(transcription: str) -> Optional[FormattingIssue]:
         FormattingIssue.INVALID_HEADER
         if not any(
             [
-                re.search(r"\*{}.*\*".format(i), header) is not None
+                re.search(r"^\**{}.*\*".format(i), header) is not None
                 for i in VALID_HEADERS
             ]
         )

--- a/tor/validation/formatting_validation.py
+++ b/tor/validation/formatting_validation.py
@@ -157,7 +157,12 @@ def check_for_invalid_header(transcription: str) -> Optional[FormattingIssue]:
     header = transcription.split("---")[0]
     return (
         FormattingIssue.INVALID_HEADER
-        if not any([re.search(r"^\**{}.*\*".format(i), header) is not None for i in VALID_HEADERS])
+        if not any(
+            [
+                re.search(r"\*{}.*\*".format(i), header) is not None
+                for i in VALID_HEADERS
+            ]
+        )
         else None
     )
 

--- a/tor/validation/formatting_validation.py
+++ b/tor/validation/formatting_validation.py
@@ -253,7 +253,7 @@ def check_for_invalid_header(transcription: str) -> Optional[FormattingIssue]:
         FormattingIssue.INVALID_HEADER
         if not any(
             [
-                re.search(r"^\**{}.*\*".format(i), header) is not None
+                re.search(r"^\s*\*+{}.*\*".format(i), header) is not None
                 for i in VALID_HEADERS
             ]
         )


### PR DESCRIPTION
Fixes #313 

This adds an anchor to check for the beginning of the text in the Invalid Header check, preventing text from coming before the header.