### PR TITLE
Add reference links formatting check

### DIFF
--- a/test/validation/test_formatting_validation.py
+++ b/test/validation/test_formatting_validation.py
@@ -353,7 +353,8 @@ def test_check_for_invalid_header(test_input: str, should_match: bool) -> None:
         ("[**Unknown User**]: Oh man i think i just ran out of pain", True),
         ("something something something [**Unknown User**]: Oh man i think i just ran out of pain", True),
         ("[**Unknown User**]:Oh man i think i just ran out of pain", True),
-        (r"\[**Unknown User**]: Oh man i think i just ran out of pain", False)
+        (r"\[**Unknown User**]: Oh man i think i just ran out of pain", False),
+        ("[*The tor bot happily smiles as the entire queue is cleared in CTQ*]", False)
     ]
 )
 def test_check_for_reference_links(test_input: str, should_match: str) -> None:

--- a/test/validation/test_formatting_validation.py
+++ b/test/validation/test_formatting_validation.py
@@ -18,6 +18,7 @@ from tor.validation.formatting_validation import (
     check_for_bold_header,
     check_for_unescaped_heading,
     check_for_invalid_header,
+    check_for_reference_links,
     PROPER_SEPARATORS_PATTERN,
     HEADING_WITH_DASHES_PATTERN,
     UNESCAPED_USERNAME_PATTERN,
@@ -342,6 +343,23 @@ def test_check_for_invalid_header(test_input: str, should_match: bool) -> None:
     """Test if invalid headers are detected."""
     actual = check_for_invalid_header(test_input)
     expected = FormattingIssue.INVALID_HEADER if should_match else None
+    assert actual == expected
+
+
+@pytest.mark.parametrize(
+    "test_input,should_match",
+    [
+        ("[lance]: https://en.wikipedia.org/wiki/Holy_Lance \"Holy Lance - Wikipedia\"", True),
+        ("[**Unknown User**]: Oh man i think i just ran out of pain", True),
+        ("something something something [**Unknown User**]: Oh man i think i just ran out of pain", True),
+        ("[**Unknown User**]:Oh man i think i just ran out of pain", True),
+        (r"\[**Unknown User**]: Oh man i think i just ran out of pain", False)
+    ]
+)
+def test_check_for_reference_links(test_input: str, should_match: str) -> None:
+    """Test if reference links are detected"""
+    actual = check_for_reference_links(test_input)
+    expected = FormattingIssue.REFERENCE_LINK if should_match else None
     assert actual == expected
 
 

--- a/tor/strings/en_US.yml
+++ b/tor/strings/en_US.yml
@@ -324,10 +324,26 @@ formatting_issues:
   invalid_header: "**Invalid header**: It looks like your header doesn't contain a proper type (Image, Video, or Audio) or is missing italics. Please make sure your post contains a proper header. For example if it's an Image Transcription, it should be the following at the top of your transcription:
 
 
-    \   *Image Transcription: Example*
+    \    *Image Transcription: Example*
 
 
     same goes for Video or Audio (but with the word `Image` replaced)."
+  reference_link: "**Reference link**: It looks like you may have inadvertently used a reference link in your transcription. Reference links usually don't display properly so it's important to escape the corresponding formatting. Here is an example of a reference link format (the end can be text too, and it'll still trigger):
+  
+  
+    \    [test]: https://en.wikipedia.org/wiki/Test
+    
+    
+    Here's what accidentally using this formatting may look like in a transcription:
+    
+    
+    \    [**Unknown User**]: Hello there!
+    
+    
+    To fix this, you simply need to escape the formatting (adding a `\\` in front), here's the above example fixed:
+    
+    
+    \    \\[**Unknown User**]: Hello there!"
 urls:
   yt_transcript_url: 'http://video.google.com/timedtext?lang=en&v={}'
   ToR_link: 'www.reddit.com/r/TranscribersOfReddit'

--- a/tor/validation/formatting_issues.py
+++ b/tor/validation/formatting_issues.py
@@ -12,3 +12,4 @@ class FormattingIssue(Enum):
     UNESCAPED_SUBREDDIT = "unescaped_subreddit"
     UNESCAPED_HEADING = "unescaped_heading"
     INVALID_HEADER = "invalid_header"
+    REFERENCE_LINK = "reference_link"

--- a/tor/validation/formatting_validation.py
+++ b/tor/validation/formatting_validation.py
@@ -79,7 +79,7 @@ VALID_HEADERS = ["Audio Transcription", "Image Transcription", "Video Transcript
 # Example:
 #
 # [Test]: Something here
-REFERENCE_LINK_PATTERN = re.compile(r"(?:[^\\]|^)\[.*]:.*")
+REFERENCE_LINK_PATTERN = re.compile(r"(?:[^\\]|^)\[.*\]:.*")
 
 # Regex to recognize double-spaced and escaped line breaks instead of paragraph breaks
 # DO:

--- a/tor/validation/formatting_validation.py
+++ b/tor/validation/formatting_validation.py
@@ -79,7 +79,7 @@ VALID_HEADERS = ["Audio Transcription", "Image Transcription", "Video Transcript
 # Example:
 #
 # [Test]: Something here
-REFERENCE_LINK_PATTERN = re.compile(r"(?:[^\\]|^)\[.*]: ?.*")
+REFERENCE_LINK_PATTERN = re.compile(r"(?:[^\\]|^)\[.*]:.*")
 
 # Regex to recognize double-spaced and escaped line breaks instead of paragraph breaks
 # DO:

--- a/tor/validation/formatting_validation.py
+++ b/tor/validation/formatting_validation.py
@@ -75,6 +75,12 @@ UNESCAPED_HEADING_PATTERN = re.compile(r"(\n[ ]*\n[ ]{,3}|^)#{1,6}[^ #]")
 # Image Transcription
 VALID_HEADERS = ["Audio Transcription", "Image Transcription", "Video Transcription"]
 
+# Regex to recognize unescaped reference links.
+# Example:
+#
+# [Test]: Something here
+REFERENCE_LINK_PATTERN = re.compile(r"(?:[^\\]|^)\[.*]: ?.*")
+
 # Regex to recognize double-spaced and escaped line breaks instead of paragraph breaks
 # DO:
 # Paragraph line break:
@@ -260,6 +266,21 @@ def check_for_invalid_header(transcription: str) -> Optional[FormattingIssue]:
     )
 
 
+def check_for_reference_links(transcription: str) -> Optional[FormattingIssue]:
+    """Check if the transcription accidentally contains reference links.
+
+    Valid: (backslash here)[**Unknown User**]: Oh man i think i just ran out of pain
+    Valid: [**Unknown User**]:Oh man i think i just ran out of pain (no space)
+    Invalid: [**Unknown User**]: Oh man i think i just ran out of pain
+    Invalid: [lance]: https://en.wikipedia.org/wiki/Holy_Lance "Holy Lance - Wikipedia"
+    """
+    return (
+        FormattingIssue.REFERENCE_LINK
+        if REFERENCE_LINK_PATTERN.search(transcription) is not None
+        else None
+    )
+
+
 def check_for_formatting_issues(transcription: str) -> Set[FormattingIssue]:
     """Check the transcription for common formatting issues."""
     return set(
@@ -275,6 +296,7 @@ def check_for_formatting_issues(transcription: str) -> Set[FormattingIssue]:
             check_for_unescaped_subreddit(transcription),
             check_for_unescaped_heading(transcription),
             check_for_invalid_header(transcription),
+            check_for_reference_links(transcription)
         ]
         if issue is not None
     )

--- a/tor/validation/formatting_validation.py
+++ b/tor/validation/formatting_validation.py
@@ -270,9 +270,10 @@ def check_for_reference_links(transcription: str) -> Optional[FormattingIssue]:
     """Check if the transcription accidentally contains reference links.
 
     Valid: (backslash here)[**Unknown User**]: Oh man i think i just ran out of pain
-    Valid: [**Unknown User**]:Oh man i think i just ran out of pain (no space)
+    Invalid: [**Unknown User**]:Oh man i think i just ran out of pain (no space)
     Invalid: [**Unknown User**]: Oh man i think i just ran out of pain
     Invalid: [lance]: https://en.wikipedia.org/wiki/Holy_Lance "Holy Lance - Wikipedia"
+    Invalid: Test test [Hello]: Hi
     """
     return (
         FormattingIssue.REFERENCE_LINK


### PR DESCRIPTION
Closes #286 

This PR adds formatting for reference links, as outlined in the corresponding issue. From my own testing, the reference link formatting doesn't trigger on Reddit when there's text before it (i.e. `Text here [Test]: hello`), however to play it on the safe side considering Reddit's finnicky-ness, the regex I used will still trigger if there's text before. If that is unwanted, replace the regex with `^\[.*]:.*`.