### PR TITLE
Update bot reply strings (reference links + "Sorry I can't find ...")

### DIFF
--- a/test/validation/test_formatting_validation.py
+++ b/test/validation/test_formatting_validation.py
@@ -354,10 +354,10 @@ def test_check_for_invalid_header(test_input: str, should_match: bool) -> None:
     "test_input,should_match",
     [
         ("[lance]: https://en.wikipedia.org/wiki/Holy_Lance \"Holy Lance - Wikipedia\"", True),
-        ("[**Unknown User**]: Oh man i think i just ran out of pain", True),
-        ("something something something [**Unknown User**]: Oh man i think i just ran out of pain", True),
-        ("[**Unknown User**]:Oh man i think i just ran out of pain", True),
-        (r"\[**Unknown User**]: Oh man i think i just ran out of pain", False),
+        ("[*Redacted*]: Oh man i think i just ran out of pain", True),
+        ("something something something [*Redacted*]: Oh man i think i just ran out of pain", True),
+        ("[*Redacted*]:Oh man i think i just ran out of pain", True),
+        (r"\[*Redacted*]: Oh man i think i just ran out of pain", False),
         ("[*The tor bot happily smiles as the entire queue is cleared in CTQ*]", False)
     ]
 )

--- a/tor/strings/en_US.yml
+++ b/tor/strings/en_US.yml
@@ -344,13 +344,13 @@ formatting_issues:
     Here's what accidentally using this formatting may look like in a transcription:
     
     
-    \    [**Unknown User**]: Hello there!
+    \    [*Redacted*]: Hello there!
     
     
     To fix this, you simply need to escape the formatting (adding a `\\` in front), here's the above example fixed:
     
     
-    \    \\[**Unknown User**]: Hello there!"
+    \    \\[*Redacted*]: Hello there!"
 urls:
   yt_transcript_url: 'http://video.google.com/timedtext?lang=en&v={}'
   ToR_link: 'www.reddit.com/r/TranscribersOfReddit'

--- a/tor/strings/en_US.yml
+++ b/tor/strings/en_US.yml
@@ -109,7 +109,7 @@ responses:
 
       If you want to help keep these bots running, please consider [donating via Patreon or Stripe](https://www.reddit.com/r/transcribersofreddit/wiki/donations)!
     cannot_find_transcript: |
-      ⛔ Sorry, I **can't find** your transcription on on the post. Please take the following actions:
+      ⛔ Sorry, I **can't find** your transcription on the post. Please take the following actions:
 
       - Make sure that you posted the transcription on the partner subreddit, not on r\/TranscribersOfReddit.
       - Make sure you have switched the comment editor from the default "Fancy Pants" to "Markdown Mode". If there's a "Markdown Mode" button in your comment box, click that.

--- a/tor/validation/formatting_validation.py
+++ b/tor/validation/formatting_validation.py
@@ -270,9 +270,9 @@ def check_for_invalid_header(transcription: str) -> Optional[FormattingIssue]:
 def check_for_reference_links(transcription: str) -> Optional[FormattingIssue]:
     """Check if the transcription accidentally contains reference links.
 
-    Valid: (backslash here)[**Unknown User**]: Oh man i think i just ran out of pain
-    Invalid: [**Unknown User**]:Oh man i think i just ran out of pain (no space)
-    Invalid: [**Unknown User**]: Oh man i think i just ran out of pain
+    Valid: (backslash here)[*Redacted*]: Oh man i think i just ran out of pain
+    Invalid: [*Redacted*]:Oh man i think i just ran out of pain (no space)
+    Invalid: [*Redacted*]: Oh man i think i just ran out of pain
     Invalid: [lance]: https://en.wikipedia.org/wiki/Holy_Lance "Holy Lance - Wikipedia"
     Invalid: Test test [Hello]: Hi
     """


### PR DESCRIPTION
Ironically this PR started out because I got sick of reading "Sorry, I **can't find** your transcription on on the post." and morphed into more. Let me know if you want me to create two PRs for this instead since the only real .... connection between these changes is that I started out in the strings file and went from there.

For the reference links: We (QA) specifically tell volunteers not to bold names within square brackets; if they're within brackets they should be italicized instead. Also, personally, I'd mostly use the brackets for redaction rather than a user's name being omitted, so I changed that as well. 