### PR TITLE
Add author and comment text to help Slack message

### DIFF
--- a/tor/core/inbox.py
+++ b/tor/core/inbox.py
@@ -78,6 +78,7 @@ def process_reply(reply: Comment, cfg: Config) -> None:
                     phrases=phrases,
                     link=reply.submission.shortlink,
                     author=reply.author.name,
+                    text=reply.body,
                 ),
                 cfg,
             )

--- a/tor/strings/en_US.yml
+++ b/tor/strings/en_US.yml
@@ -9,7 +9,11 @@ mod:
   intervention_needed: |
     :rotating_light::rotating_light: Mod Intervention Needed :rotating_light::rotating_light:
 
-    Detected use of {phrases} {link}
+    Detected use of {phrases} by u/{author}: {link}
+
+    ```
+    {text}
+    ```
   formatting_issues: |
     I detected formatting issues in the transcription by {author}: {issues}
     {link}


### PR DESCRIPTION
Closes #332.

This adds the author and comment text to the Slack message sent when the user uses the `help` command.