### PR TITLE
Update: Response to transcript on Tor post

### DIFF
--- a/tor/core/inbox.py
+++ b/tor/core/inbox.py
@@ -40,6 +40,11 @@ i18n = translation()
 log = logging.getLogger(__name__)
 
 
+def extract_sub_from_url(url: str) -> str:
+    """returns the sub name from the given url without "r/" at the start."""
+    return url.split("/")[4]
+
+
 @beeline.traced(name="forward_to_slack")
 def forward_to_slack(item: InboxableMixin, cfg: Config) -> None:
     username = str(item.author.name)
@@ -58,9 +63,6 @@ def forward_to_slack(item: InboxableMixin, cfg: Config) -> None:
 
 
 @beeline.traced(name="process_reply")
-def extract_sub_from_url(url: str) -> str:
-    # returns the sub name from the given url without "r/" at the start.
-    return url.split("/")[4]
 def process_reply(reply: Comment, cfg: Config) -> None:
     try:
         log.debug(f"Received reply from {reply.author.name}: {reply.body}")
@@ -70,7 +72,7 @@ def process_reply(reply: Comment, cfg: Config) -> None:
 
         if "image transcription" in r_body or is_comment_transcription(reply, cfg):
             post_link = submission.url
-            sub_name = extract_sub_from_url(submission.url: str) -> str
+            sub_name = extract_sub_from_url(submission.url)
             message = i18n["responses"]["general"]["transcript_on_tor_post"].format(
                 sub_name=sub_name,
                 post_link=post_link,

--- a/tor/core/inbox.py
+++ b/tor/core/inbox.py
@@ -58,6 +58,9 @@ def forward_to_slack(item: InboxableMixin, cfg: Config) -> None:
 
 
 @beeline.traced(name="process_reply")
+def extract_sub_from_url(url: str) -> str:
+    # returns the sub name from the given url without "r/" at the start.
+    return url.split("/")[4]
 def process_reply(reply: Comment, cfg: Config) -> None:
     try:
         log.debug(f"Received reply from {reply.author.name}: {reply.body}")
@@ -66,7 +69,12 @@ def process_reply(reply: Comment, cfg: Config) -> None:
         r_body = reply.body.lower()  # cache that thing
 
         if "image transcription" in r_body or is_comment_transcription(reply, cfg):
-            message = i18n["responses"]["general"]["transcript_on_tor_post"]
+            post_link = submission.url
+            sub_name = extract_sub_from_url(submission.url: str) -> str
+            message = i18n["responses"]["general"]["transcript_on_tor_post"].format(
+                sub_name=sub_name,
+                post_link=post_link,
+            )
         elif matches := [
             match.group()
             for match in [regex.search(reply.body) for regex in MOD_SUPPORT_PHRASES]

--- a/tor/core/inbox.py
+++ b/tor/core/inbox.py
@@ -71,8 +71,8 @@ def process_reply(reply: Comment, cfg: Config) -> None:
         r_body = reply.body.lower()  # cache that thing
 
         if "image transcription" in r_body or is_comment_transcription(reply, cfg):
-            post_link = submission.url
-            sub_name = extract_sub_from_url(submission.url)
+            post_link = reply.submission.url
+            sub_name = extract_sub_from_url(post_link)
             message = i18n["responses"]["general"]["transcript_on_tor_post"].format(
                 sub_name=sub_name,
                 post_link=post_link,

--- a/tor/strings/en_US.yml
+++ b/tor/strings/en_US.yml
@@ -184,8 +184,7 @@ responses:
       [Hey, you're welcome!]({})
     transcript_on_tor_post: |
       ⚠️ Hi there! I might be wrong, but I think you just posted a transcription in reply to me.
-      The transcription should be made as a **top-level comment** on the post that you're working on transcribing.
-      For example, if the content is on r\/nicegirls, then the transcription should be commented as a reply to that submission on r\/nicegirls.
+      The transcription should be made as a **top-level comment** on the [post on r\/{sub_name}]({post_link}).
       After you've commented there, come back to me and reply with `done` and I can process it!
 
       Do you need assistance? Reply to me with `help` to summon a moderator!


### PR DESCRIPTION
Closes #352 

The response when a user posts their transcription as a comment on the Tor post now guides the transcribers to the partner post:

---

**OLD:**
      The transcription should be made as a **top-level comment** on the post that you're working on transcribing.
      For example, if the content is on r\/nicegirls, then the transcription should be commented as a reply to that submission on r\/nicegirls.
      
**NEW:**
      The transcription should be made as a **top-level comment** on the \[post on r\/{sub_name}]({post_link}).