### PR TITLE
Add missing backslash in unescaped heading string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [UNRELEASED]
 
 - Track timestamp of last reddit post processed before sending to mod chat (credit: @crhopkins)
+- Add missing backslash in unescaped heading string (credit: @MurdoMaclachlan)
 
 ## [4.2.4] - 2021-04-05
 

--- a/tor/strings/en_US.yml
+++ b/tor/strings/en_US.yml
@@ -330,7 +330,7 @@ formatting_issues:
     #Text
 
 
-    To fix this, add a backslash in front of the `#` like so: `#Text`. If you meant for it to render as a heading, please add a space after the `#` to avoid this warning. i.e. `# Text`."
+    To fix this, add a backslash in front of the `#` like so: `\\#Text`. If you meant for it to render as a heading, please add a space after the `#` to avoid this warning. i.e. `# Text`."
   invalid_header: "**Invalid header**: It looks like your header doesn't contain a proper type (Image, Video, or Audio), is missing italics, and/or is not at the start of your transcription. Please make sure your post contains a proper header at the start of your transcription. For example if it's an Image Transcription, it should be the following at the start of your transcription:
 
 


### PR DESCRIPTION
Closes #350:

> In the unescaped heading warning, the section that explains how to escape the heading doesn't have a backlash in its example. This fixes that.

Hoping I read the contribution guidelines right.