### PR TITLE
Relax formatting check for reference links

### DIFF
--- a/tor/test/validation/test_formatting_validation.py
+++ b/tor/test/validation/test_formatting_validation.py
@@ -365,8 +365,18 @@ def test_check_for_invalid_header(test_input: str, should_match: bool) -> None:
         ),
         ("[*Redacted*]: Oh man i think i just ran out of pain", True),
         (
-            "something something something [*Redacted*]: Oh man i think i just ran out of pain",
+            "   [*Redacted*]: Oh man i think i just ran out of pain",
             True,
+        ),
+        # Allowed in text
+        (
+            "something something something [*Redacted*]: Oh man i think i just ran out of pain",
+            False,
+        ),
+        # Allowed in code blocks
+        (
+            "    [item.monthName]: [item.firstDay, item.lastDay]",
+            False,
         ),
         ("[*Redacted*]:Oh man i think i just ran out of pain", True),
         (r"\[*Redacted*]: Oh man i think i just ran out of pain", False),

--- a/tor/validation/formatting_validation.py
+++ b/tor/validation/formatting_validation.py
@@ -79,7 +79,7 @@ VALID_HEADERS = ["Audio Transcription", "Image Transcription", "Video Transcript
 # Example:
 #
 # [Test]: Something here
-REFERENCE_LINK_PATTERN = re.compile(r"(?:[^\\]|^)\[.*\]:.*")
+REFERENCE_LINK_PATTERN = re.compile(r"(?:^[ ]{0,3})\[.*\]:.*")
 
 # Regex to recognize double-spaced and escaped line breaks instead of paragraph breaks
 # DO:


### PR DESCRIPTION
Closes #324 (for now).

This attempts to remove false positives by only disallowing the reference link format at the start of lines.
This change will probably introduce new false negatives, but reduce the scenarios where overwrites have to be used.

For a proper fix we'd have to use a full markdown parser for Reddit markdown, which is not feasible right now.
This change should remove the need for most `!overwrite` usages for now.