### PR TITLE
Generate better exception logs

### DIFF
--- a/tor/core/helpers.py
+++ b/tor/core/helpers.py
@@ -242,7 +242,7 @@ def run_until_dead(func):
                     )
                     handle_rate_limit(e)
                 else:
-                    log.error(e)
+                    log.exception("Uncaught exception")
             except (RequestException, ServerError, Forbidden) as e:
                 log.warning(f"{e} - Issue communicating with Reddit. Sleeping for 60s!")
                 time.sleep(60)


### PR DESCRIPTION
Use `log.exception` to generate the full stack trace for uncaught exceptions.